### PR TITLE
Update plugin management logic

### DIFF
--- a/src/classes/class-pluginmanager.php
+++ b/src/classes/class-pluginmanager.php
@@ -33,17 +33,9 @@ namespace Niteo\WooCart\Defaults {
 		public $plugins = [];
 
 		/**
-		 * @var bool
+		 * Hold paths to plugin main file.
 		 */
-		public $forced_activation = false;
-
-		/**
-		 * Holds configurable array of strings.
-		 * Default values are added in the constructor.
-		 *
-		 * @var array
-		 */
-		public $strings = [];
+		public $paths = [];
 
 		/**
 		 * PluginManager constructor.
@@ -75,34 +67,6 @@ namespace Niteo\WooCart\Defaults {
 		 * Initialise the magic.
 		 */
 		public function init() {
-			// Load class strings.
-			$this->strings = [
-				/* translators: 1: plugin name(s). */
-				'notice_can_install_required'  => _n_noop(
-					'WooCart requires the following plugin: %1$s.',
-					'WooCart requires the following plugins: %1$s.',
-					'woocart-defaults'
-				),
-				/* translators: 1: plugin name(s). */
-				'notice_ask_to_update'         => _n_noop(
-					'The following plugin needs to be updated to its latest version to ensure maximum compatibility with WooCart: %1$s.',
-					'The following plugins need to be updated to their latest version to ensure maximum compatibility with WooCart: %1$s.',
-					'woocart-defaults'
-				),
-				/* translators: 1: plugin name(s). */
-				'notice_ask_to_update_maybe'   => _n_noop(
-					'There is an update available for: %1$s.',
-					'There are updates available for the following plugins: %1$s.',
-					'woocart-defaults'
-				),
-				/* translators: 1: plugin name(s). */
-				'notice_can_activate_required' => _n_noop(
-					'The following required plugin is currently inactive: %1$s.',
-					'The following required plugins are currently inactive: %1$s.',
-					'woocart-defaults'
-				),
-			];
-
 			// Check for the admin panel.
 			if ( true !== ( is_admin() && ! defined( 'DOING_AJAX' ) ) ) {
 				return;
@@ -110,9 +74,7 @@ namespace Niteo\WooCart\Defaults {
 
 			// Register plugins.
 			foreach ( $this->list as $plugin ) {
-				// @codeCoverageIgnoreStart
 				$this->register( $plugin );
-				// @codeCoverageIgnoreEnd
 			}
 
 			// Proceed only if we have plugins to handle.
@@ -120,16 +82,14 @@ namespace Niteo\WooCart\Defaults {
 				return;
 			}
 
-			if ( true !== $this->is_complete() ) {
-				// Set up the menu and notices if we still have outstanding actions.
-				add_action( 'admin_notices', [ $this, 'notices' ] );
-				add_action( 'admin_enqueue_scripts', [ $this, 'thickbox' ] );
-			}
+			// Force activate required plugins.
+			add_action( 'admin_init', [ &$this, 'force_activation' ] );
 
-			// Setup the force activation hook.
-			if ( true === $this->forced_activation ) {
-				add_action( 'admin_init', [ $this, 'force_activation' ] );
-			}
+			// Filter out the deactivate link for required plugins.
+			add_filter( 'plugin_action_links', [ &$this, 'remove_deactivation_link' ], PHP_INT_MAX, 4 );
+
+			// Add a small text to let the user know that why the plugin cannot be de-activated.
+			add_action( 'after_plugin_row', [ &$this, 'add_required_text' ], PHP_INT_MAX, 3 );
 		}
 
 		/**
@@ -146,24 +106,6 @@ namespace Niteo\WooCart\Defaults {
 			}
 
 			return get_plugins( $plugin_folder );
-		}
-
-		/**
-		 * Determine whether there are open actions for plugins.
-		 *
-		 * @return bool
-		 */
-		public function is_complete() {
-			$complete = true;
-
-			foreach ( $this->plugins as $slug => $plugin ) {
-				if ( ! $this->is_plugin_active( $slug ) || false !== $this->does_plugin_have_update( $slug ) ) {
-					$complete = false;
-					break;
-				}
-			}
-
-			return $complete;
 		}
 
 		/**
@@ -190,282 +132,25 @@ namespace Niteo\WooCart\Defaults {
 			// Retrieve a list of all installed plugins (WP cached).
 			$installed_plugins = $this->get_plugins();
 
-			return ( ! empty( $installed_plugins[ $this->plugins[ $slug ]['file_path'] ] ) );
-		}
-
-		/**
-		 * Check whether there is an update available for a plugin.
-		 *
-		 * @param string $slug Plugin slug.
-		 * @return false|string Version number string of the available update or false if no update available.
-		 */
-		public function does_plugin_have_update( $slug ) {
-			$updates = get_site_transient( 'update_plugins' );
-
+			// Ensure we have plugin in the array.
 			if ( isset( $this->plugins[ $slug ] ) ) {
-				if ( isset( $updates->response[ $this->plugins[ $slug ]['file_path'] ]->new_version ) ) {
-					return $updates->response[ $this->plugins[ $slug ]['file_path'] ]->new_version;
-				}
+				return ( ! empty( $installed_plugins[ $this->plugins[ $slug ]['file_path'] ] ) );
 			}
 
 			return false;
 		}
 
 		/**
-		 * Echoes required plugin notice.
-		 *
-		 * @global object $current_screen
-		 * @return null Returns early if we're on the Install page.
-		 *
-		 * @codeCoverageIgnore
-		 */
-		public function notices() {
-			// Remove nag on the install page.
-			if ( ( $this->is_core_update_page() ) || ! current_user_can( 'publish_posts' ) ) {
-				return;
-			}
-
-			// Store for the plugin slugs by message type.
-			$message = [];
-
-			// Initialize counters used to determine plurality of action link texts.
-			$install_link_count          = 0;
-			$update_link_count           = 0;
-			$activate_link_count         = 0;
-			$total_required_action_count = 0;
-
-			foreach ( $this->plugins as $slug => $plugin ) {
-				if ( $this->is_plugin_active( $slug ) && false === $this->does_plugin_have_update( $slug ) ) {
-					continue;
-				}
-
-				if ( ! $this->is_plugin_installed( $slug ) ) {
-					if ( current_user_can( 'install_plugins' ) ) {
-						$install_link_count++;
-						$message['notice_can_install_required'][] = $slug;
-					}
-
-					$total_required_action_count++;
-				} else {
-					if ( ! $this->is_plugin_active( $slug ) && $this->can_plugin_activate( $slug ) ) {
-						if ( current_user_can( 'activate_plugins' ) ) {
-							$activate_link_count++;
-							$message['notice_can_activate_required'][] = $slug;
-						}
-
-						$total_required_action_count++;
-					}
-
-					if ( $this->does_plugin_require_update( $slug ) || false !== $this->does_plugin_have_update( $slug ) ) {
-						if ( current_user_can( 'update_plugins' ) ) {
-							$update_link_count++;
-
-							if ( $this->does_plugin_require_update( $slug ) ) {
-								$message['notice_ask_to_update'][] = $slug;
-							} elseif ( false !== $this->does_plugin_have_update( $slug ) ) {
-								$message['notice_ask_to_update_maybe'][] = $slug;
-							}
-						}
-
-						if ( true === $plugin['required'] ) {
-							$total_required_action_count++;
-						}
-					}
-				}
-			}
-
-			unset( $slug, $plugin );
-
-			// If we have notices to display, we move forward.
-			if ( ! empty( $message ) || $total_required_action_count > 0 ) {
-				// Sort messages.
-				krsort( $message );
-				$rendered = '';
-
-				// As add_settings_error() wraps the final message in a <p> and as the final message can't be
-				// filtered, using <p>'s in our html would render invalid html output.
-				$line_template = '<span style="display: block; margin: 0.5em 0.5em 0 0; clear: both;">%s</span>' . "\n";
-
-				if ( ! current_user_can( 'activate_plugins' ) && ! current_user_can( 'install_plugins' ) && ! current_user_can( 'update_plugins' ) ) {
-					$rendered = esc_html__( 'There are one or more required plugins to install, update or activate. Please contact the administrator of this site for help.', 'woocart-defaults' );
-				} else {
-					// Render the individual message lines for the notice.
-					foreach ( $message as $type => $plugin_group ) {
-						$linked_plugins = [];
-
-						// Get the external info link for a plugin if one is available.
-						foreach ( $plugin_group as $plugin_slug ) {
-							$linked_plugins[] = $this->get_info_link( $plugin_slug );
-						}
-
-						unset( $plugin_slug );
-
-						$count       = count( $plugin_group );
-						$last_plugin = array_pop( $linked_plugins ); // Pop off last name to prep for readability.
-						$imploded    = empty( $linked_plugins ) ? $last_plugin : ( implode( ', ', $linked_plugins ) . ' ' . esc_html_x( 'and', 'plugin A *and* plugin B', 'woocart-defaults' ) . ' ' . $last_plugin );
-
-						$rendered .= sprintf(
-							$line_template,
-							sprintf(
-								translate_nooped_plural( $this->strings[ $type ], $count, 'woocart-defaults' ),
-								$imploded,
-								$count
-							)
-						);
-					}
-
-					unset( $type, $plugin_group, $linked_plugins, $count, $last_plugin, $imploded );
-				}
-
-				// Register the nag messages and prepare them to be processed.
-				add_settings_error( 'wc_plugins', 'wc_plugins', $rendered, 'notice-warning' );
-			}
-
-			// Admin options pages already output settings_errors, so this is to avoid duplication.
-			if ( 'options-general' !== $GLOBALS['current_screen']->parent_base ) {
-				$this->settings_errors();
-			}
-		}
-
-		/**
-		 * Display settings errors.
-		 */
-		protected function settings_errors() {
-			global $wp_settings_errors;
-
-			settings_errors( 'wc_plugins' );
-
-			foreach ( (array) $wp_settings_errors as $key => $details ) {
-				if ( 'wc_plugins' === $details['setting'] ) {
-					unset( $wp_settings_errors[ $key ] );
-					break;
-				}
-			}
-		}
-
-		/**
-		 * Determine if we're on a WP Core installation/upgrade page.
-		 *
-		 * @return boolean True when on a WP Core installation/upgrade page, false otherwise.
-		 */
-		protected function is_core_update_page() {
-			// Current screen is not always available, most notably on the customizer screen.
-			if ( ! function_exists( 'get_current_screen' ) ) {
-				return false;
-			}
-
-			$screen = get_current_screen();
-
-			if ( 'update-core' === $screen->base ) {
-				// Core update screen.
-				return true;
-			} elseif ( 'plugins' === $screen->base && ! empty( $_POST['action'] ) ) {
-				// Plugins bulk update screen.
-				return true;
-			} elseif ( 'update' === $screen->base && ! empty( $_POST['action'] ) ) {
-				// Individual updates (ajax call).
-				return true;
-			}
-
-			return false;
-		}
-
-		/**
-		 * Check if a plugin can be activated, i.e. is not currently active and meets the minimum
-		 * plugin version requirements set in TGMPA (if any).
-		 *
-		 * @param string $slug Plugin slug.
-		 * @return bool True if OK to activate, false otherwise.
-		 */
-		public function can_plugin_activate( $slug ) {
-			return ( ! $this->is_plugin_active( $slug ) && ! $this->does_plugin_require_update( $slug ) );
-		}
-
-		/**
-		 * Check whether a plugin complies with the minimum version requirements.
-		 *
-		 * @param string $slug Plugin slug.
-		 * @return bool True when a plugin needs to be updated, otherwise false.
-		 */
-		public function does_plugin_require_update( $slug ) {
-			$installed_version = $this->get_installed_version( $slug );
-			$minimum_version   = $this->plugins[ $slug ]['version'];
-
-			return version_compare( $minimum_version, $installed_version, '>' );
-		}
-
-		/**
-		 * Retrieve the version number of an installed plugin.
-		 *
-		 * @param string $slug Plugin slug.
-		 * @return string Version number as string or an empty string if the plugin is not installed
-		 *                or version unknown (plugins which don't comply with the plugin header standard).
-		 */
-		public function get_installed_version( $slug ) {
-			$installed_plugins = $this->get_plugins(); // Retrieve a list of all installed plugins (WP cached).
-
-			if ( isset( $this->plugins[ $slug ] ) ) {
-				if ( ! empty( $installed_plugins[ $this->plugins[ $slug ]['file_path'] ]['Version'] ) ) {
-					return $installed_plugins[ $this->plugins[ $slug ]['file_path'] ]['Version'];
-				}
-			}
-
-			return '';
-		}
-
-		/**
-		 * Retrieve a link to a plugin information page.
-		 *
-		 * @param string $slug Plugin slug.
-		 * @return string Fully formed html link to a plugin information page if available
-		 *                or the plugin name if not.
-		 */
-		public function get_info_link( $slug ) {
-			$url = add_query_arg(
-				[
-					'tab'       => 'plugin-information',
-					'plugin'    => urlencode( $slug ),
-					'TB_iframe' => 'true',
-					'width'     => '640',
-					'height'    => '500',
-				],
-				self_admin_url( 'plugin-install.php' )
-			);
-
-			$link = sprintf(
-				'<a href="%1$s" class="thickbox">%2$s</a>',
-				esc_url( $url ),
-				esc_html( $this->plugins[ $slug ]['name'] )
-			);
-
-			return $link;
-		}
-
-		/**
-		 * Enqueue thickbox scripts/styles for plugin info.
-		 *
-		 * Thickbox is not automatically included on all admin pages, so we must
-		 * manually enqueue it for those pages. Thickbox is only loaded if there are
-		 * any plugins left to install and activate.
-		 */
-		public function thickbox() {
-			add_thickbox();
-		}
-
-		/**
-		 * Forces plugin activation if the parameter 'force_activation' is
-		 * set to true.
+		 * Forces plugin activation.
 		 */
 		public function force_activation() {
 			foreach ( $this->plugins as $slug => $plugin ) {
-				if ( true === $plugin['force_activation'] ) {
-					if ( ! $this->is_plugin_installed( $slug ) ) {
-						// Oops, plugin isn't there so iterate to next condition.
-						continue;
-					} elseif ( $this->can_plugin_activate( $slug ) ) {
-						// There we go, activate the plugin.
-						activate_plugin( $plugin['file_path'] );
-					}
+				if ( ! $this->is_plugin_installed( $slug ) ) {
+					// Oops, plugin isn't there so iterate to next condition.
+					continue;
+				} elseif ( ! $this->is_plugin_active( $slug ) ) {
+					// There we go, activate the plugin.
+					activate_plugin( $plugin['file_path'] );
 				}
 			}
 		}
@@ -487,9 +172,7 @@ namespace Niteo\WooCart\Defaults {
 			$defaults = [
 				'name'             => '',      // String.
 				'slug'             => '',      // String.
-				'required'         => true,    // Boolean.
-				'version'          => '',      // String.
-				'force_activation' => false,   // Boolean.
+				'file_path' 			 => '' 			 // String.
 			];
 
 			// Prepare the received data.
@@ -497,19 +180,48 @@ namespace Niteo\WooCart\Defaults {
 
 			// Standardize the received slug.
 			$plugin['slug']             = sanitize_key( $plugin['slug'] );
-			$plugin['required']         = $plugin['required'];
-			$plugin['version']          = (string) $plugin['version'];
-			$plugin['force_activation'] = $plugin['force_activation'];
 
 			// Enrich the received data.
-			$plugin['file_path'] = $this->_get_plugin_basename_from_slug( $plugin['slug'] );
+			$plugin['file_path'] 				= $this->_get_plugin_basename_from_slug( $plugin['slug'] );
+
+			// Add to $paths if not empty.
+			if ( ! empty( $plugin['file_path'] ) ) {
+				$this->paths[] = $plugin['file_path'];
+			}
 
 			// Set the class properties.
 			$this->plugins[ $plugin['slug'] ] = $plugin;
+		}
 
-			// Should we add the force activation hook ?
-			if ( true === $plugin['force_activation'] ) {
-				$this->forced_activation = true;
+		/**
+		 * Filter function to remove deactivation links from the required plugins
+		 * on the plugins.php page.
+		 *
+		 * @param array $actions Plugin actions such as deactivate, edit.
+		 * @param string $plugin_file Path to the plugin main file relative to the plugins directory.
+		 *
+		 * @return array
+		 */
+		public function remove_deactivation_link( $actions, $plugin_file ) {
+			// Remove deactivate link for important plugins.
+			if ( array_key_exists( 'deactivate', $actions ) && in_array( $plugin_file, $this->paths ) ) {
+				unset( $actions['deactivate'] );
+			}
+
+			return $actions;
+		}
+
+		/**
+		 * Add required text below the plugin row on the page.
+		 *
+		 * @param string $plugin_file Path to the plugin main file relative to the plugins directory.
+		 * @param array $plugin_data Plugin data such as name, description, etc.
+		 *
+		 * @return void
+		 */
+		public function add_required_text( $plugin_file, $plugin_data ) {
+			if ( in_array( $plugin_file, $this->paths ) ) {
+				echo '<tr><td colspan="3" style="background:#fcd670"><strong>' . $plugin_data['Name'] . '</strong> is a required plugin on WooCart and cannot be deactivated.</td></tr>';
 			}
 		}
 

--- a/src/classes/class-pluginmanager.php
+++ b/src/classes/class-pluginmanager.php
@@ -34,6 +34,8 @@ namespace Niteo\WooCart\Defaults {
 
 		/**
 		 * Hold paths to plugin main file.
+		 *
+		 * @var array
 		 */
 		public $paths = [];
 
@@ -74,19 +76,7 @@ namespace Niteo\WooCart\Defaults {
 
 			// Register plugins.
 			foreach ( $this->list as $plugin ) {
-				/**
-				 * Special case for Sendgrid.
-				 * We register the plugin only if the the `SENDGRID_API_KEY` is defined.
-				 *
-				 * @see https://github.com/niteoweb/woocart-docker-web/blob/master/fixtures/config/wp-config.php
-				 */
-				if ( 'sendgrid-email-delivery-simplified' === $plugin['slug'] ) {
-					if ( defined( 'SENDGRID_API_KEY' ) ) {
-						$this->register( $plugin );
-					}
-				} else {
-					$this->register( $plugin );
-				}
+				$this->register( $plugin );
 			}
 
 			// Proceed only if we have plugins to handle.
@@ -97,11 +87,8 @@ namespace Niteo\WooCart\Defaults {
 			// Force activate required plugins.
 			add_action( 'admin_init', [ &$this, 'force_activation' ] );
 
-			// Filter out the deactivate link for required plugins.
-			add_filter( 'plugin_action_links', [ &$this, 'remove_deactivation_link' ], PHP_INT_MAX, 4 );
-
-			// Add a small text to let the user know that why the plugin cannot be de-activated.
-			add_action( 'after_plugin_row', [ &$this, 'add_required_text' ], PHP_INT_MAX, 3 );
+			// Execute other functions.
+			add_action( 'current_screen', [ &$this, 'plugins_page' ] );
 		}
 
 		/**
@@ -164,6 +151,24 @@ namespace Niteo\WooCart\Defaults {
 					// There we go, activate the plugin.
 					activate_plugin( $plugin['file_path'] );
 				}
+			}
+		}
+
+		/**
+		 * Execute other functions on the plugins.php page
+		 */
+		public function plugins_page() {
+			// Get the current screen to ensure that the functions only get executed
+			// on the plugins.php page
+			$screen = get_current_screen();
+
+			// Only on plugins page.
+			if ( 'plugins' === $screen->id ) {
+				// Filter out the deactivate link for required plugins.
+				add_filter( 'plugin_action_links', [ &$this, 'remove_deactivation_link' ], PHP_INT_MAX, 4 );
+
+				// Add a small text to let the user know that why the plugin cannot be de-activated.
+				add_action( 'after_plugin_row', [ &$this, 'add_required_text' ], PHP_INT_MAX, 3 );
 			}
 		}
 

--- a/src/classes/class-pluginmanager.php
+++ b/src/classes/class-pluginmanager.php
@@ -170,19 +170,19 @@ namespace Niteo\WooCart\Defaults {
 			}
 
 			$defaults = [
-				'name'             => '',      // String.
-				'slug'             => '',      // String.
-				'file_path' 			 => '' 			 // String.
+				'name'      => '',      // String.
+				'slug'      => '',      // String.
+				'file_path' => '',           // String.
 			];
 
 			// Prepare the received data.
 			$plugin = wp_parse_args( $plugin, $defaults );
 
 			// Standardize the received slug.
-			$plugin['slug']             = sanitize_key( $plugin['slug'] );
+			$plugin['slug'] = sanitize_key( $plugin['slug'] );
 
 			// Enrich the received data.
-			$plugin['file_path'] 				= $this->_get_plugin_basename_from_slug( $plugin['slug'] );
+			$plugin['file_path'] = $this->_get_plugin_basename_from_slug( $plugin['slug'] );
 
 			// Add to $paths if not empty.
 			if ( ! empty( $plugin['file_path'] ) ) {
@@ -197,7 +197,7 @@ namespace Niteo\WooCart\Defaults {
 		 * Filter function to remove deactivation links from the required plugins
 		 * on the plugins.php page.
 		 *
-		 * @param array $actions Plugin actions such as deactivate, edit.
+		 * @param array  $actions Plugin actions such as deactivate, edit.
 		 * @param string $plugin_file Path to the plugin main file relative to the plugins directory.
 		 *
 		 * @return array
@@ -215,7 +215,7 @@ namespace Niteo\WooCart\Defaults {
 		 * Add required text below the plugin row on the page.
 		 *
 		 * @param string $plugin_file Path to the plugin main file relative to the plugins directory.
-		 * @param array $plugin_data Plugin data such as name, description, etc.
+		 * @param array  $plugin_data Plugin data such as name, description, etc.
 		 *
 		 * @return void
 		 */

--- a/src/classes/class-pluginmanager.php
+++ b/src/classes/class-pluginmanager.php
@@ -74,7 +74,19 @@ namespace Niteo\WooCart\Defaults {
 
 			// Register plugins.
 			foreach ( $this->list as $plugin ) {
-				$this->register( $plugin );
+				/**
+				 * Special case for Sendgrid.
+				 * We register the plugin only if the the `SENDGRID_API_KEY` is defined.
+				 *
+				 * @see https://github.com/niteoweb/woocart-docker-web/blob/master/fixtures/config/wp-config.php
+				 */
+				if ( 'sendgrid-email-delivery-simplified' === $plugin['slug'] ) {
+					if ( defined( 'SENDGRID_API_KEY' ) ) {
+						$this->register( $plugin );
+					}
+				} else {
+					$this->register( $plugin );
+				}
 			}
 
 			// Proceed only if we have plugins to handle.

--- a/tests/PluginManagerTest.php
+++ b/tests/PluginManagerTest.php
@@ -130,8 +130,7 @@ class PluginManagerTest extends TestCase {
 		->andReturn( 'autoptimize/autoptimize.php' );
 
 		\WP_Mock::expectActionAdded( 'admin_init', [ $mock, 'force_activation' ] );
-		\WP_Mock::expectActionAdded( 'after_plugin_row', [ $mock, 'add_required_text' ], PHP_INT_MAX, 3 );
-		\WP_Mock::expectFilterAdded( 'plugin_action_links', [ $mock, 'remove_deactivation_link' ], PHP_INT_MAX, 4 );
+		\WP_Mock::expectActionAdded( 'current_screen', [ $mock, 'plugins_page' ] );
 
 		$mock->init();
 	}
@@ -185,10 +184,31 @@ class PluginManagerTest extends TestCase {
 		->andReturn( 'autoptimize/autoptimize.php' );
 
 		\WP_Mock::expectActionAdded( 'admin_init', [ $mock, 'force_activation' ] );
-		\WP_Mock::expectActionAdded( 'after_plugin_row', [ $mock, 'add_required_text' ], PHP_INT_MAX, 3 );
-		\WP_Mock::expectFilterAdded( 'plugin_action_links', [ $mock, 'remove_deactivation_link' ], PHP_INT_MAX, 4 );
+		\WP_Mock::expectActionAdded( 'current_screen', [ $mock, 'plugins_page' ] );
 
 		$mock->init();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::__construct
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::plugins_page
+	 */
+	public function testPluginsPage() {
+		$plugins = new PluginManager();
+
+		\WP_Mock::userFunction(
+			'get_current_screen',
+			[
+				'return' => (object) [
+					'id' => 'plugins',
+				],
+			]
+		);
+
+		\WP_Mock::expectActionAdded( 'after_plugin_row', [ $plugins, 'add_required_text' ], PHP_INT_MAX, 3 );
+		\WP_Mock::expectFilterAdded( 'plugin_action_links', [ $plugins, 'remove_deactivation_link' ], PHP_INT_MAX, 4 );
+
+		$plugins->plugins_page();
 	}
 
 	/**
@@ -387,7 +407,7 @@ class PluginManagerTest extends TestCase {
 	 * @covers \Niteo\WooCart\Defaults\PluginManager::__construct
 	 * @covers \Niteo\WooCart\Defaults\PluginManager::force_activation
 	 * @covers \Niteo\WooCart\Defaults\PluginManager::is_plugin_active
-	 * * @covers \Niteo\WooCart\Defaults\PluginManager::is_plugin_installed
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::is_plugin_installed
 	 */
 	public function testForceActivationTwo() {
 		$mock          = \Mockery::mock( 'Niteo\WooCart\Defaults\PluginManager' )->makePartial();
@@ -407,7 +427,7 @@ class PluginManagerTest extends TestCase {
 		$mock->shouldReceive( 'is_plugin_installed' )
 		->andReturn( true );
 		$mock->shouldReceive( 'is_plugin_active' )
-		->andReturn( true );
+		->andReturn( false );
 		\WP_Mock::userFunction(
 			'activate_plugin',
 			[

--- a/tests/PluginManagerTest.php
+++ b/tests/PluginManagerTest.php
@@ -93,8 +93,10 @@ class PluginManagerTest extends TestCase {
 						->shouldAllowMockingProtectedMethods()
 						->makePartial();
 		$mock->list    = [
-			'name' => 'Autoptimize',
-			'slug' => 'autoptimize',
+			[
+				'name' => 'Autoptimize',
+				'slug' => 'autoptimize',
+			],
 		];
 		$mock->plugins = [
 			'name' => 'Autoptimize',
@@ -124,8 +126,61 @@ class PluginManagerTest extends TestCase {
 			]
 		);
 
-		// $mock->shouldReceive( 'register' )
-		// ->andReturn( true );
+		$mock->shouldReceive( '_get_plugin_basename_from_slug' )
+		->andReturn( 'autoptimize/autoptimize.php' );
+
+		\WP_Mock::expectActionAdded( 'admin_init', [ $mock, 'force_activation' ] );
+		\WP_Mock::expectActionAdded( 'after_plugin_row', [ $mock, 'add_required_text' ], PHP_INT_MAX, 3 );
+		\WP_Mock::expectFilterAdded( 'plugin_action_links', [ $mock, 'remove_deactivation_link' ], PHP_INT_MAX, 4 );
+
+		$mock->init();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::__construct
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::init
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::register
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::is_plugin_active
+	 */
+	public function testInitTwo() {
+		define( 'SENDGRID_API_KEY', true );
+		$mock          = \Mockery::mock( 'Niteo\WooCart\Defaults\PluginManager' )
+						->shouldAllowMockingProtectedMethods()
+						->makePartial();
+		$mock->list    = [
+			[
+				'name' => 'Sendgrid',
+				'slug' => 'sendgrid-email-delivery-simplified',
+			],
+		];
+		$mock->plugins = [
+			'name' => 'Autoptimize',
+			'slug' => 'autoptimize',
+		];
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			[
+				'return' => true,
+			]
+		);
+		\WP_Mock::userFunction(
+			'wp_parse_args',
+			[
+				'return' => [
+					'name'      => 'Autoptimize',
+					'slug'      => 'autoptimize',
+					'file_path' => '',
+				],
+			]
+		);
+		\WP_Mock::userFunction(
+			'sanitize_key',
+			[
+				'return' => 'autoptimize',
+			]
+		);
+
 		$mock->shouldReceive( '_get_plugin_basename_from_slug' )
 		->andReturn( 'autoptimize/autoptimize.php' );
 

--- a/tests/PluginManagerTest.php
+++ b/tests/PluginManagerTest.php
@@ -30,8 +30,8 @@ class PluginManagerTest extends TestCase {
 			'WOOCART_REQUIRED',
 			[
 				[
-					'name'     => 'Autoptimize',
-					'slug'     => 'autoptimize',
+					'name' => 'Autoptimize',
+					'slug' => 'autoptimize',
 				],
 			]
 		);
@@ -89,16 +89,16 @@ class PluginManagerTest extends TestCase {
 	 * @covers \Niteo\WooCart\Defaults\PluginManager::is_plugin_active
 	 */
 	public function testInit() {
-		$mock                    = \Mockery::mock( 'Niteo\WooCart\Defaults\PluginManager' )
+		$mock          = \Mockery::mock( 'Niteo\WooCart\Defaults\PluginManager' )
 						->shouldAllowMockingProtectedMethods()
 						->makePartial();
-		$mock->list = [
-			'name'     => 'Autoptimize',
-			'slug'     => 'autoptimize'
+		$mock->list    = [
+			'name' => 'Autoptimize',
+			'slug' => 'autoptimize',
 		];
-		$mock->plugins           = [
-			'name'     => 'Autoptimize',
-			'slug'     => 'autoptimize',
+		$mock->plugins = [
+			'name' => 'Autoptimize',
+			'slug' => 'autoptimize',
 		];
 
 		\WP_Mock::userFunction(
@@ -111,9 +111,9 @@ class PluginManagerTest extends TestCase {
 			'wp_parse_args',
 			[
 				'return' => [
-					'name'             => 'Autoptimize',
-					'slug'             => 'autoptimize',
-					'file_path'        => '',
+					'name'      => 'Autoptimize',
+					'slug'      => 'autoptimize',
+					'file_path' => '',
 				],
 			]
 		);
@@ -147,9 +147,9 @@ class PluginManagerTest extends TestCase {
 			'wp_parse_args',
 			[
 				'return' => [
-					'name'             => 'Autoptimize',
-					'slug'             => 'autoptimize',
-					'file_path'        => '',
+					'name'      => 'Autoptimize',
+					'slug'      => 'autoptimize',
+					'file_path' => '',
 				],
 			]
 		);
@@ -172,8 +172,8 @@ class PluginManagerTest extends TestCase {
 
 		$mock->register(
 			[
-				'name'             => 'Autoptimize',
-				'slug'             => 'autoptimize',
+				'name' => 'Autoptimize',
+				'slug' => 'autoptimize',
 			]
 		);
 	}
@@ -206,11 +206,11 @@ class PluginManagerTest extends TestCase {
 	 * @covers \Niteo\WooCart\Defaults\PluginManager::is_plugin_active
 	 */
 	public function testIsPluginActive() {
-		$plugins = new PluginManager();
+		$plugins          = new PluginManager();
 		$plugins->plugins = [
 			'autoptimize' => [
-				'file_path' => 'autoptimize/autoptimize.php'
-			]
+				'file_path' => 'autoptimize/autoptimize.php',
+			],
 		];
 
 		\WP_Mock::userFunction(
@@ -228,9 +228,9 @@ class PluginManagerTest extends TestCase {
 	 * @covers \Niteo\WooCart\Defaults\PluginManager::add_required_text
 	 */
 	public function testAddRequiredText() {
-		$plugins = new PluginManager();
+		$plugins        = new PluginManager();
 		$plugins->paths = [
-			'plugin_file'
+			'plugin_file',
 		];
 
 		$plugins->add_required_text( 'plugin_file', [ 'Name' => 'Plugin' ] );
@@ -242,12 +242,21 @@ class PluginManagerTest extends TestCase {
 	 * @covers \Niteo\WooCart\Defaults\PluginManager::remove_deactivation_link
 	 */
 	public function testRemoveDeactivationLink() {
-		$plugins = new PluginManager();
+		$plugins        = new PluginManager();
 		$plugins->paths = [
-			'plugin_file'
+			'plugin_file',
 		];
 
-		$this->assertEquals( [ 'Another' => 'This will be returned' ], $plugins->remove_deactivation_link( [ 'deactivate' => 'Link', 'Another' => 'This will be returned' ], 'plugin_file' ) );
+		$this->assertEquals(
+			[ 'Another' => 'This will be returned' ],
+			$plugins->remove_deactivation_link(
+				[
+					'deactivate' => 'Link',
+					'Another'    => 'This will be returned',
+				],
+				'plugin_file'
+			)
+		);
 	}
 
 	/**
@@ -304,9 +313,9 @@ class PluginManagerTest extends TestCase {
 		$mock          = \Mockery::mock( 'Niteo\WooCart\Defaults\PluginManager' )->makePartial();
 		$mock->plugins = [
 			'autoptimize' => [
-				'name'             => 'Autoptimize',
-				'slug'             => 'autoptimize',
-				'file_path'        => 'autoptimize/autoptimize.php',
+				'name'      => 'Autoptimize',
+				'slug'      => 'autoptimize',
+				'file_path' => 'autoptimize/autoptimize.php',
 			],
 		];
 		$mock->shouldReceive( 'get_plugins' )
@@ -329,9 +338,9 @@ class PluginManagerTest extends TestCase {
 		$mock          = \Mockery::mock( 'Niteo\WooCart\Defaults\PluginManager' )->makePartial();
 		$mock->plugins = [
 			'autoptimize' => [
-				'name'             => 'Autoptimize',
-				'slug'             => 'autoptimize',
-				'file_path'        => 'autoptimize/autoptimize.php',
+				'name'      => 'Autoptimize',
+				'slug'      => 'autoptimize',
+				'file_path' => 'autoptimize/autoptimize.php',
 			],
 		];
 		$mock->shouldReceive( 'get_plugins' )
@@ -363,9 +372,9 @@ class PluginManagerTest extends TestCase {
 		$mock          = \Mockery::mock( 'Niteo\WooCart\Defaults\PluginManager' )->makePartial();
 		$mock->plugins = [
 			'autoptimize' => [
-				'name'             => 'Autoptimize',
-				'slug'             => 'autoptimize',
-				'file_path'        => 'autoptimize/autoptimize.php',
+				'name'      => 'Autoptimize',
+				'slug'      => 'autoptimize',
+				'file_path' => 'autoptimize/autoptimize.php',
 			],
 		];
 		$mock->shouldReceive( 'is_plugin_installed' )


### PR DESCRIPTION
Ref: https://github.com/niteoweb/woocart/issues/629

This PR updates the plugin management logic to accommodate the following:

- Assert that required plugins always stay activated.
- Remove `admin_notices`.
- Remove `deactivate` link from the `plugins.php` page for the plugin.
- Add a message below the plugin row to let the user know that the plugin is required on WooCart and cannot be deactivated.