### PR TITLE
Fix the sales report's end date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.8.2
+VERSION := 3.8.3
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/class-cli-command.php
+++ b/src/classes/class-cli-command.php
@@ -210,7 +210,7 @@ namespace Niteo\WooCart\Defaults {
 			include_once WP_PLUGIN_DIR . '/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php';
 			$sales_by_date                 = new \WC_Report_Sales_By_Date();
 			$sales_by_date->start_date     = strtotime( date( 'Y-m-d 00:00:00', strtotime( '-1 day' ) ) );
-			$sales_by_date->end_date       = strtotime( date( 'Y-m-d 23:59:59', strtotime( '-1 day' ) ) );
+			$sales_by_date->end_date       = strtotime( date( 'Y-m-d 00:00:00', strtotime( '-1 day' ) ) );
 			$sales_by_date->chart_groupby  = 'day';
 			$sales_by_date->group_by_query = 'YEAR(posts.post_date), MONTH(posts.post_date), DAY(posts.post_date)';
 


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/674

Our query setup to get daily sales report from WooCommerce was this (from [class-cli-command.php](https://github.com/woocart/defaults/blob/23ccf3b5c02d7523ca3953e9e87d4ab54ba28ec8/src/classes/class-cli-command.php#L212)):

    $sales_by_date->start_date     = strtotime( date( 'Y-m-d 00:00:00', strtotime( '-1 day' ) ) );
    $sales_by_date->end_date       = strtotime( date( 'Y-m-d 23:59:59', strtotime( '-1 day' ) ) );

Looks good, "take sales from beginning of the day to the end of the day".
The problem is that [WooCommerce does this](https://docs.woocommerce.com/wc-apidocs/source-class-WC_Admin_Report.html#225):

    $query['where'] .= "
        AND     posts.post_date >= '" . date( 'Y-m-d H:i:s', $this->start_date ) . "'
        AND     posts.post_date < '" . date( 'Y-m-d H:i:s', strtotime( '+1 DAY', $this->end_date ) ) . "'
    ";

This PR fixes our query.

