### PR TITLE
Fix JS error

### DIFF
--- a/src/assets/js/front-gdpr.js
+++ b/src/assets/js/front-gdpr.js
@@ -12,9 +12,12 @@ function setCookie(name, value, days) {
 }
 
 var consent = getCookie( 'woocart-gdpr' );
+var element = document.querySelector( '.wc-defaults-gdpr' );
 
 if (consent === null) {
-	document.querySelector( '.wc-defaults-gdpr' ).style.display = 'block';
+	if (document.body.contains( element )) {
+		element.style.display = 'block';
+	}
 }
 
 document.addEventListener(
@@ -31,7 +34,9 @@ document.addEventListener(
 		setCookie( 'woocart-gdpr', 'agree', 180 );
 
 		// Hide consent bar.
-		document.querySelector( '.wc-defaults-gdpr' ).style.display = 'none';
+		if (document.body.contains( element )) {
+			element.style.display = 'none';
+		}
 	},
 	false
 );


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart-app/issues/702

Fixes the JS error which is triggered if the `div` does not exist on the page which is possible if the admin has de-activated the cookie notification.

We are checking the element using `document.body.contains` to confirm it's existence. According to MDN, this is supported across all browsers.