### PR TITLE
Add GDPR compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "psr-4": {
       "Niteo\\WooCart\\Defaults\\": "classes",
       "Niteo\\WooCart\\Defaults\\Importers\\": "importers",
-      "Niteo\\WooCart\\Defaults\\Generators\\": "generators"
+      "Niteo\\WooCart\\Defaults\\Generators\\": "generators",
+      "Niteo\\WooCart\\Defaults\\Extend\\": "classes/traits"
     }
   }
 }

--- a/src/classes/class-gdpr.php
+++ b/src/classes/class-gdpr.php
@@ -18,12 +18,19 @@ namespace Niteo\WooCart\Defaults {
 	 */
 	class GDPR {
 
+		use Extend\WooCommerce;
+
 		/**
 		 * GDPR constructor.
 		 */
 		public function __construct() {
 			add_action( 'wp_footer', [ &$this, 'show_consent' ] );
 			add_action( 'wp_enqueue_scripts', [ &$this, 'scripts' ] );
+
+			// WooCommerce checkout form customizations for GDPR compliance.
+			add_action( 'woocommerce_checkout_after_terms_and_conditions', [ &$this, 'privacy_checkbox' ] );
+			add_action( 'woocommerce_checkout_process', [ &$this, 'show_notice' ] );
+			add_action( 'woocommerce_checkout_update_order_meta', [ &$this, 'update_order_meta' ] );
 
 			if ( is_admin() ) {
 				/**

--- a/src/classes/class-gdpr.php
+++ b/src/classes/class-gdpr.php
@@ -32,6 +32,9 @@ namespace Niteo\WooCart\Defaults {
 			add_action( 'woocommerce_checkout_process', [ &$this, 'show_notice' ] );
 			add_action( 'woocommerce_checkout_update_order_meta', [ &$this, 'update_order_meta' ] );
 
+			// Process shortcode for terms and conditions checkbox text.
+			add_filter( 'woocommerce_get_terms_and_conditions_checkbox_text', 'do_shortcode' );
+
 			if ( is_admin() ) {
 				/**
 				 * Set priority one so that the menu item shows just below the default

--- a/src/classes/class-gdpr.php
+++ b/src/classes/class-gdpr.php
@@ -19,6 +19,7 @@ namespace Niteo\WooCart\Defaults {
 	class GDPR {
 
 		use Extend\WooCommerce;
+		use Extend\WPCF7;
 
 		/**
 		 * GDPR constructor.
@@ -31,6 +32,9 @@ namespace Niteo\WooCart\Defaults {
 			add_action( 'woocommerce_checkout_after_terms_and_conditions', [ &$this, 'privacy_checkbox' ] );
 			add_action( 'woocommerce_checkout_process', [ &$this, 'show_notice' ] );
 			add_action( 'woocommerce_checkout_update_order_meta', [ &$this, 'update_order_meta' ] );
+
+			// Add privacy checkbox to all contact forms.
+			add_action( 'wpcf7_init', [ &$this, 'cf_privacy_checkbox' ] );
 
 			// Process shortcode for terms and conditions checkbox text.
 			add_filter( 'woocommerce_get_terms_and_conditions_checkbox_text', 'do_shortcode' );

--- a/src/classes/traits/woocommerce.php
+++ b/src/classes/traits/woocommerce.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Extends the GDPR functionality.
+ */
+
+namespace Niteo\WooCart\Defaults\Extend {
+
+  trait WooCommerce {
+
+    /**
+     * Adds a custom checkbox to the woocommerce checkout for Privacy Policy.
+     */
+    public function privacy_checkbox() {
+      $privacy_text = do_shortcode(
+        __( 'I\'ve read and accept the [policy-page]<a href="%s">Privacy Policy</a>[/policy-page]', 'woocart-defaults' )
+      );
+
+      // WooCommerce checkbox for privacy text.
+      woocommerce_form_field(
+        'woocart_privacy_checkbox', [
+          'type'      => 'checkbox',
+          'label'     => $privacy_text,
+          'required'  => true
+        ]
+      );
+    }
+
+    /**
+     * For showing notice if the checkbox is unchecked.
+     */
+    public function show_notice() {
+      global $woocommerce;
+
+      if ( ! $_POST['woocart_privacy_checkbox'] ) {
+        wc_add_notice( esc_html__( 'Please read and accept the Privacy Policy to proceed with your order.', 'woocart-defaults' ), 'error' );
+      }
+    }
+
+    /**
+     * Update order meta and include the privacy checkbox value.
+     */
+    public function update_order_meta( $order_id ) {
+      if ( $_POST['woocart_privacy_checkbox'] ) {
+        update_post_meta( $order_id, 'woocart_privacy_checkbox', esc_attr( $_POST['woocart_privacy_checkbox'] ) );
+      }
+    }
+  }
+}

--- a/src/classes/traits/woocommerce.php
+++ b/src/classes/traits/woocommerce.php
@@ -12,6 +12,12 @@ namespace Niteo\WooCart\Defaults\Extend {
 		 * Adds a custom checkbox to the woocommerce checkout for Privacy Policy.
 		 */
 		public function privacy_checkbox() {
+			// Check for user and associated privacy meta.
+			// If meta exists, simply return nothing.
+			if ( $this->check_user() ) {
+				return;
+			}
+
 			$privacy_text = do_shortcode(
 				__( 'I\'ve read and accept the [policy-page]<a href="%s">Privacy Policy</a>[/policy-page]', 'woocart-defaults' )
 			);
@@ -33,6 +39,12 @@ namespace Niteo\WooCart\Defaults\Extend {
 		public function show_notice() {
 			global $woocommerce;
 
+			// Check for user and associated privacy meta.
+			// If meta exists, simply return nothing.
+			if ( $this->check_user() ) {
+				return;
+			}
+
 			if ( ! isset( $_POST['woocart_privacy_checkbox'] ) || empty( $_POST['woocart_privacy_checkbox'] ) ) {
 				wc_add_notice( esc_html__( 'Please read and accept the Privacy Policy to proceed with your order.', 'woocart-defaults' ), 'error' );
 			}
@@ -43,8 +55,35 @@ namespace Niteo\WooCart\Defaults\Extend {
 		 */
 		public function update_order_meta( $order_id ) {
 			if ( isset( $_POST['woocart_privacy_checkbox'] ) && ! empty( isset( $_POST['woocart_privacy_checkbox'] ) ) ) {
-				update_post_meta( $order_id, 'woocart_privacy_checkbox', esc_attr( $_POST['woocart_privacy_checkbox'] ) );
+				$user_id = get_current_user_id();
+
+				// We have a user logged in. We update the user meta instead of post meta.
+				if ( $user_id ) {
+					update_user_meta( $user_id, 'woocart_privacy_checkbox', esc_attr( $_POST['woocart_privacy_checkbox'] ) );
+				} else {
+					update_post_meta( $order_id, 'woocart_privacy_checkbox', esc_attr( $_POST['woocart_privacy_checkbox'] ) );
+				}
 			}
+		}
+
+		/**
+		 * Check for logged in user.
+		 *
+		 * @return boolean
+		 */
+		public function check_user() {
+			$user_id = get_current_user_id();
+
+			// The above function returns 0 if there is no user logged in.
+			if ( $user_id ) {
+				$user_meta = get_user_meta( $user_id, 'woocart_privacy_checkbox', true );
+
+				if ( ! empty( $user_meta ) ) {
+					return true;
+				}
+			}
+
+			return false;
 		}
 	}
 }

--- a/src/classes/traits/woocommerce.php
+++ b/src/classes/traits/woocommerce.php
@@ -6,44 +6,45 @@
 
 namespace Niteo\WooCart\Defaults\Extend {
 
-  trait WooCommerce {
+	trait WooCommerce {
 
-    /**
-     * Adds a custom checkbox to the woocommerce checkout for Privacy Policy.
-     */
-    public function privacy_checkbox() {
-      $privacy_text = do_shortcode(
-        __( 'I\'ve read and accept the [policy-page]<a href="%s">Privacy Policy</a>[/policy-page]', 'woocart-defaults' )
-      );
+		/**
+		 * Adds a custom checkbox to the woocommerce checkout for Privacy Policy.
+		 */
+		public function privacy_checkbox() {
+			$privacy_text = do_shortcode(
+				__( 'I\'ve read and accept the [policy-page]<a href="%s">Privacy Policy</a>[/policy-page]', 'woocart-defaults' )
+			);
 
-      // WooCommerce checkbox for privacy text.
-      woocommerce_form_field(
-        'woocart_privacy_checkbox', [
-          'type'      => 'checkbox',
-          'label'     => $privacy_text,
-          'required'  => true
-        ]
-      );
-    }
+			// WooCommerce checkbox for privacy text.
+			woocommerce_form_field(
+				'woocart_privacy_checkbox',
+				[
+					'type'     => 'checkbox',
+					'label'    => $privacy_text,
+					'required' => true,
+				]
+			);
+		}
 
-    /**
-     * For showing notice if the checkbox is unchecked.
-     */
-    public function show_notice() {
-      global $woocommerce;
+		/**
+		 * For showing notice if the checkbox is unchecked.
+		 */
+		public function show_notice() {
+			global $woocommerce;
 
-      if ( ! $_POST['woocart_privacy_checkbox'] ) {
-        wc_add_notice( esc_html__( 'Please read and accept the Privacy Policy to proceed with your order.', 'woocart-defaults' ), 'error' );
-      }
-    }
+			if ( ! isset( $_POST['woocart_privacy_checkbox'] ) || empty( $_POST['woocart_privacy_checkbox'] ) ) {
+				wc_add_notice( esc_html__( 'Please read and accept the Privacy Policy to proceed with your order.', 'woocart-defaults' ), 'error' );
+			}
+		}
 
-    /**
-     * Update order meta and include the privacy checkbox value.
-     */
-    public function update_order_meta( $order_id ) {
-      if ( $_POST['woocart_privacy_checkbox'] ) {
-        update_post_meta( $order_id, 'woocart_privacy_checkbox', esc_attr( $_POST['woocart_privacy_checkbox'] ) );
-      }
-    }
-  }
+		/**
+		 * Update order meta and include the privacy checkbox value.
+		 */
+		public function update_order_meta( $order_id ) {
+			if ( isset( $_POST['woocart_privacy_checkbox'] ) && ! empty( isset( $_POST['woocart_privacy_checkbox'] ) ) ) {
+				update_post_meta( $order_id, 'woocart_privacy_checkbox', esc_attr( $_POST['woocart_privacy_checkbox'] ) );
+			}
+		}
+	}
 }

--- a/src/classes/traits/wpcf7.php
+++ b/src/classes/traits/wpcf7.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Extends the GDPR functionality.
+ */
+
+namespace Niteo\WooCart\Defaults\Extend {
+
+	trait WPCF7 {
+
+		/**
+		 * Adds a privacy checkbox using contact form acceptance tag.
+		 */
+		public function cf_privacy_checkbox() {
+			// First, we get the contact form ID's from the posts table.
+			$forms = $this->get_forms();
+
+			// Next, we add the acceptance tag to the CF template.
+			$this->update_template( $forms );
+		}
+
+		/**
+		 * Get contact forms from the posts table.
+		 */
+		public function get_forms() {
+			return get_posts(
+				[
+					'post_type'      => 'wpcf7_contact_form',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				]
+			);
+		}
+
+		/**
+		 * Update cf template stored in post meta.
+		 */
+		public function update_template( $forms = [] ) {
+			if ( count( $forms ) > 0 ) {
+				foreach ( $forms as $form_id ) {
+					$content = get_post_meta( $form_id, '_form', true );
+
+					// Check if the form does not have acceptance tag already.
+					$pattern = '/(\[acceptance?.*\])/';
+					preg_match( $pattern, $content, $matches );
+
+					if ( empty( $matches ) ) {
+						// Add acceptance tag to the form template.
+						$privacy_text   = do_shortcode(
+							__( 'I\'ve read and accept the [policy-page]<a href="%s">Privacy Policy</a>[/policy-page]', 'woocart-defaults' )
+						);
+						$acceptance_tag = '[acceptance accept-this-1] ' . $privacy_text . ' [/acceptance]';
+						$content        = str_replace( '[submit', $acceptance_tag . "\n\n[submit", $content );
+
+						update_post_meta( $form_id, '_form', $content );
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/composer.json
+++ b/src/composer.json
@@ -19,7 +19,8 @@
   "autoload": {
     "psr-4": {
       "Niteo\\WooCart\\Defaults\\": "classes",
-      "Niteo\\WooCart\\Defaults\\Importers\\": "importers"
+      "Niteo\\WooCart\\Defaults\\Importers\\": "importers",
+      "Niteo\\WooCart\\Defaults\\Extend\\": "classes/traits"
     }
   },
   "require-dev": {

--- a/tests/GdprTest.php
+++ b/tests/GdprTest.php
@@ -214,4 +214,71 @@ class GDPRTest extends TestCase {
 
 		$gdpr->update_order_meta( 10 );
 	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\GDPR::__construct
+	 * @covers \Niteo\WooCart\Defaults\GDPR::cf_privacy_checkbox
+	 * @covers \Niteo\WooCart\Defaults\GDPR::get_forms
+	 * @covers \Niteo\WooCart\Defaults\GDPR::update_template
+	 */
+	public function testCfPrivacyCheckbox() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\GDPR' )
+											->makePartial();
+		$mock->shouldReceive(
+			[
+				'get_forms'       => true,
+				'update_template' => true,
+			]
+		);
+
+		$mock->cf_privacy_checkbox();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\GDPR::__construct
+	 * @covers \Niteo\WooCart\Defaults\GDPR::get_forms
+	 */
+	public function testGetForms() {
+		$gdpr = new GDPR();
+		\WP_Mock::userFunction(
+			'get_posts',
+			[
+				'times'  => 1,
+				'return' => true,
+			]
+		);
+
+		$gdpr->get_forms();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\GDPR::__construct
+	 * @covers \Niteo\WooCart\Defaults\GDPR::update_template
+	 */
+	public function testUpdateTemplate() {
+		$gdpr = new GDPR();
+		\WP_Mock::userFunction(
+			'get_post_meta',
+			[
+				'times'  => 1,
+				'return' => 'Content form template [name] [email] [submit]',
+			]
+		);
+		\WP_Mock::userFunction(
+			'do_shortcode',
+			[
+				'times'  => 1,
+				'return' => 'privacy policy text',
+			]
+		);
+		\WP_Mock::userFunction(
+			'update_post_meta',
+			[
+				'times'  => 1,
+				'return' => true,
+			]
+		);
+
+		$gdpr->update_template( [ 30 ] );
+	}
 }

--- a/tests/GdprTest.php
+++ b/tests/GdprTest.php
@@ -55,8 +55,9 @@ class GDPRTest extends TestCase {
 		\WP_Mock::expectActionAdded( 'woocommerce_checkout_after_terms_and_conditions', [ $gdpr, 'privacy_checkbox' ] );
 		\WP_Mock::expectActionAdded( 'woocommerce_checkout_process', [ $gdpr, 'show_notice' ] );
 		\WP_Mock::expectActionAdded( 'woocommerce_checkout_update_order_meta', [ $gdpr, 'update_order_meta' ] );
-
 		\WP_Mock::expectActionAdded( 'admin_menu', [ $gdpr, 'add_menu_item' ], 1 );
+
+		\WP_Mock::expectFilterAdded( 'woocommerce_get_terms_and_conditions_checkbox_text', 'do_shortcode' );
 
 		$gdpr->__construct();
 		$gdpr->scripts();


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/779
Refs https://github.com/niteoweb/woocart/issues/780

This PR adds GDPR compliance to the WooCommerce checkout process and Contact Form 7. The code has been added to the `GDPR` class which already exists in the plugin.

I added the code using `traits` so that it is easier to understand at a glance. Traits have been added in a separate folder within the `classes` folder.
- `woocommerce.php`
- `wpcf7.php`
