### PR TITLE
Fix color for the cookie bar links

### DIFF
--- a/src/assets/css/front-gdpr.css
+++ b/src/assets/css/front-gdpr.css
@@ -13,9 +13,9 @@
 	margin: 0 !important;
 	text-align: center;
 }
-.wc-defaults-gdpr a.wcil,
-.wc-defaults-gdpr a.wcil:hover,
-.wc-defaults-gdpr a.wcil:focus {
+.wc-defaults-gdpr a:not(#wc-defaults-ok),
+.wc-defaults-gdpr a:not(#wc-defaults-ok):hover,
+.wc-defaults-gdpr a:not(#wc-defaults-ok):focus {
 	color: #ffffff !important;
 	text-decoration: underline;
 }


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/686#issuecomment-499077873

Links in the cookie bar were using the default link colors of the website. Changed to be always white with an underline.