### PR TITLE
Conditional GDPR for WooCommerce

### DIFF
--- a/src/classes/class-gdpr.php
+++ b/src/classes/class-gdpr.php
@@ -28,13 +28,16 @@ namespace Niteo\WooCart\Defaults {
 			add_action( 'wp_footer', [ &$this, 'show_consent' ] );
 			add_action( 'wp_enqueue_scripts', [ &$this, 'scripts' ] );
 
-			// WooCommerce checkout form customizations for GDPR compliance.
-			add_action( 'woocommerce_checkout_after_terms_and_conditions', [ &$this, 'privacy_checkbox' ] );
-			add_action( 'woocommerce_checkout_process', [ &$this, 'show_notice' ] );
-			add_action( 'woocommerce_checkout_update_order_meta', [ &$this, 'update_order_meta' ] );
+			// Don't extend if the option is disabled.
+			if ( 'yes' === get_option( 'wc_gdpr_extend', 'yes' ) ) {
+				// WooCommerce checkout form customizations for GDPR compliance.
+				add_action( 'woocommerce_checkout_after_terms_and_conditions', [ &$this, 'privacy_checkbox' ] );
+				add_action( 'woocommerce_checkout_process', [ &$this, 'show_notice' ] );
+				add_action( 'woocommerce_checkout_update_order_meta', [ &$this, 'update_order_meta' ] );
 
-			// Add privacy checkbox to all contact forms.
-			add_action( 'wpcf7_init', [ &$this, 'cf_privacy_checkbox' ] );
+				// Add privacy checkbox to all contact forms.
+				add_action( 'wpcf7_init', [ &$this, 'cf_privacy_checkbox' ] );
+			}
 
 			// Process shortcode for terms and conditions checkbox text.
 			add_filter( 'woocommerce_get_terms_and_conditions_checkbox_text', 'do_shortcode' );
@@ -137,9 +140,11 @@ namespace Niteo\WooCart\Defaults {
 				if ( 'set-cookies-page' === $action ) {
 					$notification_message   = isset( $_POST['notification_message'] ) ? (string) $_POST['notification_message'] : '';
 					$cookies_policy_page_id = isset( $_POST['page_for_cookies_policy'] ) ? (int) $_POST['page_for_cookies_policy'] : 0;
+					$extend_gdpr            = isset( $_POST['extend_gdpr_compliance'] ) ? (string) $_POST['extend_gdpr_compliance'] : 'no';
 
 					update_option( 'wc_gdpr_notification_message', sanitize_text_field( $notification_message ) );
 					update_option( 'wp_page_for_cookies_policy', $cookies_policy_page_id );
+					update_option( 'wc_gdpr_extend', $extend_gdpr );
 
 					$cookies_page_updated_message = esc_html__( 'Cookies Policy page and notification message has been updated successfully.', 'woocart-defaults' );
 
@@ -339,6 +344,21 @@ namespace Niteo\WooCart\Defaults {
 				<?php endif; ?>
 			  </td>
 			</tr>
+	  <tr>
+		<th scope="row">
+				  <?php esc_html_e( 'Extend GDPR compliance' ); ?>
+			  </th>
+
+		<td>
+		  <label for="extend_gdpr_compliance">
+			<input name="extend_gdpr_compliance" type="checkbox" id="extend_gdpr_compliance" value="yes" <?php checked( 'yes', get_option( 'wc_gdpr_extend', 'yes' ) ); ?> />
+					  <?php esc_html_e( 'This extends GDPR compliance to plugins such as WooCommerce, Contact Form 7 and others.' ); ?>
+					</label>
+		</td>
+		<td>
+
+		</td>
+	  </tr>
 						<tr>
 							<th scope="row"></th>
 							<td>

--- a/src/classes/class-gdpr.php
+++ b/src/classes/class-gdpr.php
@@ -352,7 +352,7 @@ namespace Niteo\WooCart\Defaults {
 		<td>
 		  <label for="extend_gdpr_compliance">
 			<input name="extend_gdpr_compliance" type="checkbox" id="extend_gdpr_compliance" value="yes" <?php checked( 'yes', get_option( 'wc_gdpr_extend', 'yes' ) ); ?> />
-					  <?php esc_html_e( 'This extends GDPR compliance to plugins such as WooCommerce, Contact Form 7 and others.' ); ?>
+					  <?php esc_html_e( 'This extends GDPR compliance to plugins such as WooCommerce and Contact Form 7.' ); ?>
 					</label>
 		</td>
 		<td>

--- a/tests/GdprTest.php
+++ b/tests/GdprTest.php
@@ -43,6 +43,13 @@ class GDPRTest extends TestCase {
 			)
 		);
 		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 2,
+				'return' => 'yes',
+			)
+		);
+		\WP_Mock::userFunction(
 			'is_admin',
 			array(
 				'times'  => 2,

--- a/tests/GdprTest.php
+++ b/tests/GdprTest.php
@@ -26,35 +26,40 @@ class GDPRTest extends TestCase {
 	public function testConstructor() {
 		\WP_Mock::userFunction(
 			'plugin_dir_url',
-			array(
+			[
 				'times' => 1,
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'wp_enqueue_style',
-			array(
-				'args' => [ 'woocart-gdpr', '/assets/css/front-gdpr.css', [], '@##VERSION##@' ],
-			)
+			[
+				'args' => [
+					'woocart-gdpr',
+					'/assets/css/front-gdpr.css',
+					[],
+					'@##VERSION##@',
+				],
+			]
 		);
 		\WP_Mock::userFunction(
 			'wp_enqueue_script',
-			array(
+			[
 				'args' => [ 'woocart-gdpr', '/assets/js/front-gdpr.js', [], '@##VERSION##@', true ],
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'get_option',
-			array(
+			[
 				'times'  => 2,
 				'return' => 'yes',
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'is_admin',
-			array(
+			[
 				'times'  => 2,
 				'return' => true,
-			)
+			]
 		);
 		$gdpr = new GDPR();
 		\WP_Mock::expectActionAdded( 'wp_footer', [ $gdpr, 'show_consent' ] );
@@ -79,9 +84,9 @@ class GDPRTest extends TestCase {
 		$gdpr = new GDPR();
 		\WP_Mock::userFunction(
 			'add_options_page',
-			array(
+			[
 				'times' => 1,
-			)
+			]
 		);
 
 		$gdpr->add_menu_item();
@@ -95,65 +100,65 @@ class GDPRTest extends TestCase {
 		$gdpr = new GDPR();
 		\WP_Mock::userFunction(
 			'is_admin',
-			array(
+			[
 				'return' => true,
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'get_option',
-			array(
+			[
 				'args'   => 'woocommerce_allow_tracking',
 				'return' => 'no',
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'get_option',
-			array(
+			[
 				'args'   => [
 					'wc_gdpr_notification_message',
 					'We use cookies to improve your experience on our site. To find out more, read our [privacy_policy] and [cookies_policy].',
 				],
 				'return' => 'Test message with [privacy_policy] and [cookies_policy]',
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'get_option',
-			array(
+			[
 				'args'   => 'wp_page_for_privacy_policy',
 				'return' => true,
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'get_option',
-			array(
+			[
 				'args'   => 'wp_page_for_cookies_policy',
 				'return' => true,
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'absint',
-			array(
+			[
 				'return' => true,
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'get_permalink',
-			array(
+			[
 				'return' => 'https://woocart.com',
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'sanitize_text_field',
-			array(
+			[
 				'times'  => 2,
 				'return' => 'Replace Link',
-			)
+			]
 		);
 		\WP_Mock::userFunction(
 			'get_the_title',
-			array(
+			[
 				'times' => 2,
-			)
+			]
 		);
 
 		$gdpr->show_consent();


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/1093

This PR adds the option to disable addition of GDPR compliance to plugins - `WooCommerce` and `Contact Form 7`.

**Preview:**

<img width="1064" alt="Screenshot 2019-10-02 at 6 27 10 PM" src="https://user-images.githubusercontent.com/266324/66045972-6238c280-e542-11e9-8663-48d94ef8a8d1.png">
