### PR TITLE
Add business name option

### DIFF
--- a/src/classes/class-woocommerce.php
+++ b/src/classes/class-woocommerce.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Niteo\WooCart\Defaults {
+
+	/**
+	 * Class WooCommerce
+	 *
+	 * @package Niteo\WooCart\Defaults
+	 */
+	class WooCommerce {
+
+		public function __construct() {
+			add_filter( 'woocommerce_general_settings', [ &$this, 'general_settings' ] );
+		}
+
+		/**
+		 * Return updated options for the general settings page.
+		 *
+		 * @return array
+		 */
+		public function general_settings( $settings ) {
+			$updated_settings = [];
+
+			foreach ( $settings as $section ) {
+				// Check for general settings
+				if ( isset( $section['id'] ) && 'general_options' == $section['id'] && isset( $section['type'] ) && 'sectionend' == $section['type'] ) {
+					$option = [
+						'name'     => esc_html__( 'Business Name', 'woocart-defaults' ),
+						'desc_tip' => esc_html__( 'Name of the business used for operating the store.', 'woocart-defaults' ),
+						'id'       => 'woocommerce_company_name',
+						'type'     => 'text',
+						'default'  => '',
+					];
+
+					// Add to the top of the options
+					array_splice( $updated_settings, 1, 0, [ $option ] );
+				}
+
+				$updated_settings[] = $section;
+			}
+
+			return $updated_settings;
+		}
+
+	}
+
+}

--- a/src/i18n/woocart-defaults.pot
+++ b/src/i18n/woocart-defaults.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 WooCart
+# Copyright (C) 2019 WooCart
 # This file is distributed under the same license as the WooCart Defaults plugin.
 msgid ""
 msgstr ""
@@ -9,9 +9,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2018-12-07T12:49:42+01:00\n"
-"PO-Revision-Date: 2018-12-07T12:49:42+01:00\n"
-"X-Generator: WP-CLI 2.0.1\n"
+"POT-Creation-Date: 2019-10-30T17:25:02+05:30\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.2.0\n"
 "X-Domain: woocart-defaults\n"
 
 #. Plugin Name of the plugin
@@ -23,6 +23,7 @@ msgid "Manage and deploy WordPress + WooCommerce configuration changes."
 msgstr ""
 
 #. Author of the plugin
+#: classes/class-shortcodes.php:212
 msgid "WooCart"
 msgstr ""
 
@@ -30,74 +31,184 @@ msgstr ""
 msgid "www.woocart.com"
 msgstr ""
 
-#: classes/class-gdpr.php:50
-msgid "We use cookies to improve your experience on our site. To find out more, read our <a href=\"%1$s\" class=\"wcil\">Privacy Policy</a> and <a href=\"%2$s\" class=\"wcil\">Cookie Policy</a>."
+#: classes/traits/woocommerce.php:22
+#: classes/traits/wpcf7.php:50
+msgid "I've read and accept the [policy-page]<a href=\"%s\">Privacy Policy</a>[/policy-page]"
 msgstr ""
 
-#: classes/class-gdpr.php:61
+#: classes/traits/woocommerce.php:49
+msgid "Please read and accept the Privacy Policy to proceed with your order."
+msgstr ""
+
+#: classes/class-woocommerce.php:28
+msgid "Business Name"
+msgstr ""
+
+#: classes/class-woocommerce.php:29
+msgid "Name of the business used for operating the store."
+msgstr ""
+
+#: classes/class-cachemanager.php:132
+#: classes/class-cachemanager.php:134
+msgid "Flush Cache"
+msgstr ""
+
+#: classes/class-cachemanager.php:150
+msgid "Your request does not seem to be a valid one."
+msgstr ""
+
+#: classes/class-cachemanager.php:200
+msgid "Cache has been flushed successfully."
+msgstr ""
+
+#: classes/class-cachemanager.php:202
+msgid "Dismiss this notice."
+msgstr ""
+
+#: classes/class-democleaner.php:55
+msgid "WooCart Turnkey Store"
+msgstr ""
+
+#: classes/class-democleaner.php:108
+msgid "Demo content does not seem to exist for the store."
+msgstr ""
+
+#: classes/class-democleaner.php:202
+msgid "Your store came installed with demo products. When you're ready you can safely remove them with one click by clicking the button below."
+msgstr ""
+
+#: classes/class-democleaner.php:205
+msgid "Remove Demo Products"
+msgstr ""
+
+#: classes/class-gdpr.php:102
 msgid "OK"
 msgstr ""
 
-#: classes/class-admindashboard.php:58
-msgid "Welcome to your new store!"
+#: classes/class-gdpr.php:114
+msgid "Cookies Policy & Notification Settings"
 msgstr ""
 
-#: classes/class-admindashboard.php:59
-msgid "You are only a few steps away from selling."
+#: classes/class-gdpr.php:115
+msgid "Cookies Policy & Notification"
 msgstr ""
 
-#: classes/class-admindashboard.php:65
-msgid "Connect a Payment Gateway"
+#: classes/class-gdpr.php:132
+msgid "Sorry, you are not allowed to manage Cookies Policy page on this site."
+msgstr ""
+
+#: classes/class-gdpr.php:149
+msgid "Cookies Policy page and notification message has been updated successfully."
+msgstr ""
+
+#: classes/class-gdpr.php:165
+msgid "Cookies Policy page updated successfully. Remember to <a href=\"%s\">update your menus</a>!"
+msgstr ""
+
+#: classes/class-gdpr.php:180
+msgid "Cookies Policy"
+msgstr ""
+
+#: classes/class-gdpr.php:183
+msgid "Enter content for your Cookies policy in this section."
+msgstr ""
+
+#: classes/class-gdpr.php:192
+msgid "Unable to create a Cookies Policy page."
+msgstr ""
+
+#: classes/class-gdpr.php:215
+msgid "The currently selected Cookies Policy page does not exist. Please create or select a new page."
+msgstr ""
+
+#: classes/class-gdpr.php:224
+msgid "The currently selected Cookies Policy page is in the trash. Please create or select a new Cookies Policy page or <a href=\"%s\">restore the current page</a>."
+msgstr ""
+
+#: classes/class-gdpr.php:264
+msgid "<a href=\"%1$s\">Edit</a> or <a href=\"%2$s\">view</a> your Cookies Policy page content."
+msgstr ""
+
+#: classes/class-gdpr.php:266
+msgid "<a href=\"%1$s\">Edit</a> or <a href=\"%2$s\">preview</a> your Cookies Policy page content."
+msgstr ""
+
+#: classes/class-gdpr.php:290
+msgid "To insert links for privacy policy and cookie policy pages, make use of the placeholders - <strong>[privacy_policy]</strong> and <strong>[cookies_policy]</strong>. If you do not wish to show the GDPR notice on your store, you can do so by deleting notification text from the above field."
+msgstr ""
+
+#: classes/class-gdpr.php:336
+msgid "&mdash; Select &mdash;"
+msgstr ""
+
+#: classes/class-gdpr.php:370
+msgid "Save Settings"
+msgstr ""
+
+#: classes/class-gdpr.php:398
+msgid "Create New Page"
 msgstr ""
 
 #: classes/class-admindashboard.php:66
-msgid "To start receiving payments, you'll need to set up a payment gateway."
+msgid "Welcome to your new store!"
 msgstr ""
 
 #: classes/class-admindashboard.php:67
+msgid "You are only a few steps away from selling."
+msgstr ""
+
+#: classes/class-admindashboard.php:73
+msgid "Connect a Payment Gateway"
+msgstr ""
+
+#: classes/class-admindashboard.php:74
+msgid "To start receiving payments, you'll need to set up a payment gateway."
+msgstr ""
+
+#: classes/class-admindashboard.php:75
 msgid "Here are the instructions and the recommended plugins for the popular gateways:"
 msgstr ""
 
-#: classes/class-admindashboard.php:82
+#: classes/class-admindashboard.php:90
 msgid "Connect a Shipping Courier"
 msgstr ""
 
-#: classes/class-admindashboard.php:83
+#: classes/class-admindashboard.php:91
 msgid "If you prepare shipping slips automatically, you'll need to use a shipping courier plugin."
 msgstr ""
 
-#: classes/class-admindashboard.php:84
+#: classes/class-admindashboard.php:92
 msgid "Here are the recommended plugins for the most popular couriers:"
 msgstr ""
 
-#: classes/class-admindashboard.php:96
+#: classes/class-admindashboard.php:104
 msgid "Add Your Products"
 msgstr ""
 
-#: classes/class-admindashboard.php:101
+#: classes/class-admindashboard.php:109
 msgid "Add your products manually or import a CSV with the <a href=\"%s\">WooCommerce import</a>."
 msgstr ""
 
-#: classes/class-admindashboard.php:122
+#: classes/class-admindashboard.php:130
 msgid "Add Your Own Logo and Slider Banners"
 msgstr ""
 
-#: classes/class-admindashboard.php:126
-msgid "You'll want to add your own logo and banners to the store. You can use something like %sthe free tool <a href=\"https://www.canva.com/create/banners/\" target=\"_blank\" rel=\"noopener noreferrer\">Canva</a> to create these graphics."
-msgstr ""
-
-#: classes/class-admindashboard.php:138
-msgid "Start Customizing"
+#: classes/class-admindashboard.php:134
+msgid "You'll want to add your own logo and banners to the store. You can use something like the free tool <a href=\"https://www.canva.com/create/banners/\" target=\"_blank\" rel=\"noopener noreferrer\">Canva</a> to create these graphics."
 msgstr ""
 
 #: classes/class-admindashboard.php:146
+msgid "Start Customizing"
+msgstr ""
+
+#: classes/class-admindashboard.php:154
 msgid "Test The Checkout"
 msgstr ""
 
-#: classes/class-admindashboard.php:147
+#: classes/class-admindashboard.php:155
 msgid "Go through the buying process and review that everything is working as it should."
 msgstr ""
 
-#: classes/class-admindashboard.php:149
+#: classes/class-admindashboard.php:157
 msgid "Visit Your Store"
 msgstr ""

--- a/src/index.php
+++ b/src/index.php
@@ -26,6 +26,7 @@ namespace Niteo\WooCart {
 	use Niteo\WooCart\Defaults\PluginLogger;
 	use Niteo\WooCart\Defaults\CacheManager;
 	use Niteo\WooCart\Defaults\DemoCleaner;
+	use Niteo\WooCart\Defaults\WooCommerce;
 
 	if ( class_exists( 'WP_CLI' ) ) {
 		\WP_CLI::add_command( 'wcd', __NAMESPACE__ . '\Defaults\CLI_Command' );
@@ -53,6 +54,7 @@ namespace Niteo\WooCart {
 			new CacheManager();
 			new Reporter();
 			new DemoCleaner();
+			new WooCommerce();
 		}
 	}
 }

--- a/tests/WooCommerceTest.php
+++ b/tests/WooCommerceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Niteo\WooCart\Defaults\WooCommerce;
+use PHPUnit\Framework\TestCase;
+
+class WooCommerceTest extends TestCase {
+
+
+	function setUp() {
+		\WP_Mock::setUp();
+	}
+
+	function tearDown() {
+		$this->addToAssertionCount(
+			\Mockery::getContainer()->mockery_getExpectationCount()
+		);
+		\WP_Mock::tearDown();
+		\Mockery::close();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WooCommerce::__construct
+	 */
+	public function testConstructor() {
+		$woocommerce = new WooCommerce();
+		\WP_Mock::expectFilterAdded( 'woocommerce_general_settings', [ $woocommerce, 'general_settings' ] );
+
+		$woocommerce->__construct();
+		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WooCommerce::__construct
+	 * @covers \Niteo\WooCart\Defaults\WooCommerce::general_settings
+	 */
+	public function testGeneralSettings() {
+		$woocommerce = new WooCommerce();
+
+		$this->assertEquals(
+			$woocommerce->general_settings(
+				[
+					[
+						'id'   => 'general_options',
+						'type' => 'sectionend',
+					],
+				]
+			),
+			[
+				[
+					'name'     => 'Business Name',
+					'desc_tip' => 'Name of the business used for operating the store.',
+					'id'       => 'woocommerce_company_name',
+					'type'     => 'text',
+					'default'  => '',
+				],
+				[
+					'id'   => 'general_options',
+					'type' => 'sectionend',
+				],
+			]
+		);
+	}
+
+}


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1159

Adds `woocommerce_company_name` option to the WooCommerce's general settings page. This option is used for the `[company_name]` shortcode.