### PR TITLE
Update dashboard welcome screen

### DIFF
--- a/src/classes/class-admindashboard.php
+++ b/src/classes/class-admindashboard.php
@@ -18,6 +18,8 @@ namespace Niteo\WooCart\Defaults {
 	 */
 	class AdminDashboard {
 
+		use Extend\Proteus;
+
 		protected $admin_url;
 
 		/**
@@ -69,56 +71,25 @@ namespace Niteo\WooCart\Defaults {
 				<div class="welcome-panel-column-container">
 					<div class="welcome-panel-column">
 						<div class="welcome-panel-inner">
-							<!-- Connect a payment gateway -->
-							<h3><?php esc_html_e( 'Connect a Payment Gateway', 'woocart-defaults' ); ?></h3>
-							<p><?php esc_html_e( 'To start receiving payments, you\'ll need to set up a payment gateway.', 'woocart-defaults' ); ?></p>
-							<p><?php esc_html_e( 'Here are the instructions and the recommended plugins for the popular gateways:', 'woocart-defaults' ); ?></p>
-							<ul>
-								<li><a href="<?php echo $this->admin_url; ?>plugin-install.php?tab=plugin-information&plugin=woocommerce-gateway-paypal-express-checkout&TB_iframe=true&width=772&height=306" class="thickbox">PayPal</a></li>
-								<li><a href="<?php echo $this->admin_url; ?>plugin-install.php?tab=plugin-information&plugin=woocommerce-gateway-stripe&TB_iframe=true&width=772&height=306" class="thickbox">Stripe</a></li>
-								<li><a href="<?php echo $this->admin_url; ?>plugin-install.php?tab=plugin-information&plugin=klarna-checkout-for-woocommerce&TB_iframe=true&width=772&height=306" class="thickbox">Klarna</a></li>
-								<li><a href="<?php echo $this->admin_url; ?>plugin-install.php?tab=plugin-information&plugin=woocommerce-gateway-paypal-powered-by-braintree&TB_iframe=true&width=772&height=306" class="thickbox">BrainTree</a></li>
-								<li><a href="<?php echo $this->admin_url; ?>plugin-install.php?tab=plugin-information&plugin=paymill&TB_iframe=true&width=772&height=306" class="thickbox">Paymill</a></li>
-								<li><a href="<?php echo $this->admin_url; ?>plugin-install.php?tab=plugin-information&plugin=woo-payu-payment-gateway&TB_iframe=true&width=772&height=306" class="thickbox">PayU</a></li>
-							</ul>
+							<!-- Logo & slider banners -->
+							<h3><?php esc_html_e( 'Add Your Own Logo and Slider Banners', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'You can use something like the free tool Canva to create these graphics. Add them in the theme <a href="%1$s">Customizer</a>', esc_url( get_admin_url( null, 'customize.php' ) ) ); ?></p>
 						</div>
 					</div>
 
 					<div class="welcome-panel-column">
 						<div class="welcome-panel-inner">
-							<!-- Connect a shipping courier -->
-							<h3><?php esc_html_e( 'Connect a Shipping Courier', 'woocart-defaults' ); ?></h3>
-							<p><?php esc_html_e( 'If you prepare shipping slips automatically, you\'ll need to use a shipping courier plugin.', 'woocart-defaults' ); ?></p>
-							<p><?php esc_html_e( 'Here are the recommended plugins for the most popular couriers:', 'woocart-defaults' ); ?></p>
-							<ul>
-								<li><a href="<?php echo $this->admin_url; ?>plugin-install.php?tab=plugin-information&plugin=dhl-for-woocommerce&TB_iframe=true&width=772&height=306" class="thickbox">DHL</a></li>
-								<li><a href="https://woocommerce.com/products/fedex-shipping-module/" target="_blank" rel="noopener noreferrer">FedEx</a></li>
-								<li><a href="<?php echo $this->admin_url; ?>plugin-install.php?tab=plugin-information&plugin=flexible-shipping-ups&TB_iframe=true&width=772&height=306" class="thickbox">UPS</a></li>
-							</ul>
+							<!-- Add your products -->
+							<h3><?php esc_html_e( 'Add Your Products', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'Add your products manually or import a CSV with the WooCommerce import. Go to <a href="%1$s">Import products</a>.', esc_url( get_admin_url( null, 'edit.php?post_type=product&page=product_importer' ) ) ); ?></p>
 						</div>
 					</div>
 
 					<div class="welcome-panel-column welcome-panel-last">
 						<div class="welcome-panel-inner">
-							<!-- Add your products -->
-							<h3><?php esc_html_e( 'Add Your Products', 'woocart-defaults' ); ?></h3>
-							<p>
-							<?php
-							printf(
-								wp_kses(
-									__( 'Add your products manually or import a CSV with the <a href="%s">WooCommerce import</a>.', 'woocart-defaults' ),
-									array(
-										'a' => array(
-											'href' => array(),
-										),
-									)
-								),
-								esc_url(
-									get_admin_url( null, 'edit.php?post_type=product&page=product_importer' )
-								)
-							);
-							?>
-							</p>
+							<!-- Connect a payment gateway -->
+							<h3><?php esc_html_e( 'Connect a Payment Gateway', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'To start receiving payments, you\'ll need to set up a payment gateway. Go to <a href="%1$s">Plugins</a>', admin_url( 'plugins.php' ) ); ?></p>
 						</div>
 					</div>
 				</div>
@@ -126,36 +97,17 @@ namespace Niteo\WooCart\Defaults {
 				<div class="welcome-panel-column-container">
 					<div class="welcome-panel-column">
 						<div class="welcome-panel-inner">
-							<!-- Logo & slider banners -->
-							<h3><?php esc_html_e( 'Add Your Own Logo and Slider Banners', 'woocart-defaults' ); ?></h3>
-							<p>
-							<?php
-							echo wp_kses(
-								__( 'You\'ll want to add your own logo and banners to the store. You can use something like the free tool <a href="https://www.canva.com/create/banners/" target="_blank" rel="noopener noreferrer">Canva</a> to create these graphics.', 'woocart-defaults' ),
-								array(
-									'a' => array(
-										'href'   => array(),
-										'target' => array(),
-										'rel'    => array(),
-									),
-								)
-							);
-							?>
-							</p>
-							<ul>
-								<li><a href="<?php echo esc_url( get_admin_url( null, 'customize.php' ) ); ?>"><?php esc_html_e( 'Start Customizing', 'woocart-defaults' ); ?></a></li>
-							</ul>
+							<!-- Test checkout -->
+							<h3><?php esc_html_e( 'Test The Checkout', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'Go through the buying process and review that everything is working as it should. <a href="%1$s">Visit your store</a>', esc_url( get_site_url() ) ); ?></p>
 						</div>
 					</div>
 
 					<div class="welcome-panel-column welcome-panel-last">
 						<div class="welcome-panel-inner">
-							<!-- Test checkout -->
-							<h3><?php esc_html_e( 'Test The Checkout', 'woocart-defaults' ); ?></h3>
-							<p><?php esc_html_e( 'Go through the buying process and review that everything is working as it should.', 'woocart-defaults' ); ?></p>
-							<ul>
-								<li><a href="<?php echo esc_url( get_site_url() ); ?>" target="_blank"><?php esc_html_e( 'Visit Your Store', 'woocart-defaults' ); ?></a></li>
-							</ul>
+							<!-- Set domain -->
+							<h3><?php esc_html_e( 'Set the Domain in WooCart', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'Ready to publish and stop using <em>mywoocart.com</em> subdomain? <a href="%1$s" target="_blank">Go to WooCart</a> and set your domain under Settings.', 'https://woocart.com' ); ?></p>
 						</div>
 					</div>
 				</div>

--- a/src/classes/class-admindashboard.php
+++ b/src/classes/class-admindashboard.php
@@ -38,7 +38,13 @@ namespace Niteo\WooCart\Defaults {
 				$this->admin_url = esc_url( get_admin_url() );
 
 				remove_action( 'welcome_panel', 'wp_welcome_panel' );
-				add_action( 'welcome_panel', [ &$this, 'welcome_panel' ] );
+
+				// check if the proteus theme is active
+				if ( $this->is_proteus_active() ) {
+					add_action( 'welcome_panel', [ &$this, 'proteus_welcome_panel' ] );
+				} else {
+					add_action( 'welcome_panel', [ &$this, 'welcome_panel' ] );
+				}
 
 				// add thickbox to the dashboard page
 				add_thickbox();
@@ -53,6 +59,9 @@ namespace Niteo\WooCart\Defaults {
 		public function welcome_panel() {
 			?>
 			<style>
+				.welcome-panel {
+					padding-bottom: 20px;
+				}
 				.welcome-panel-content .welcome-panel-column .welcome-panel-inner,
 				.welcome-panel-content h2,
 				.welcome-panel-content .about-description {

--- a/src/classes/traits/proteus.php
+++ b/src/classes/traits/proteus.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Dashboard functionality for the proteus theme setup.
+ */
+
+namespace Niteo\WooCart\Defaults\Extend {
+
+	trait Proteus {
+
+		/**
+		 * Checks for the active theme to see if it's the proteus one or not.
+		 *
+		 * @return boolean
+		 */
+		public function check_active_theme() {
+			$theme = wp_get_theme();
+
+			// Looking for "WoonderShop" name for the theme or parent theme
+			if ( 'WoonderShop' === $theme->name || 'WoonderShop' === $theme->parent_theme ) {
+				return true;
+			}
+
+			return false;
+		}
+
+		/**
+		 * Welcome panel for the proteus theme setup.
+		 *
+		 * @codeCoverageIgnore
+		 */
+		public function proteus_welcome_panel() {
+			?>
+	  <style>
+				.welcome-panel-content .welcome-panel-column .welcome-panel-inner,
+				.welcome-panel-content h2,
+				.welcome-panel-content .about-description {
+					padding: 0 10px;
+				}
+				.welcome-panel-content li {
+					display: inline-block;
+					margin-right: 13px;
+				}
+			</style>
+
+			<div class="welcome-panel-content">
+				<h2><?php esc_html_e( 'Welcome to your new store!', 'woocart-defaults' ); ?></h2>
+				<p class="about-description"><?php esc_html_e( 'You are only a few steps away from selling.', 'woocart-defaults' ); ?></p>
+
+				<div class="welcome-panel-column-container">
+					<div class="welcome-panel-column">
+						<div class="welcome-panel-inner">
+							<!-- Install theme demo content -->
+							<h3><?php esc_html_e( 'Install the theme demo content', 'woocart-defaults' ); ?></h3>
+							<p><?php esc_html_e( 'Woohoo! You successfully created your demo website. This quick setup process is powered by our One Click Demo Import, which is included in every theme.', 'woocart-defaults' ); ?></p>
+						</div>
+					</div>
+
+					<div class="welcome-panel-column">
+						<div class="welcome-panel-inner">
+							<!-- Upload logo -->
+							<h3><?php esc_html_e( 'Upload your logo', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'Go to <span class="sandbox-setting-path">Appearance > Customize > Theme options > <a href="%1$s">Logo</a></span>. Don\'t forget to click on <em>Save & Publish</em>.', admin_url( 'customize.php?autofocus[control]=logo_img' ) ); ?></p>
+						</div>
+					</div>
+
+					<div class="welcome-panel-column welcome-panel-last">
+						<div class="welcome-panel-inner">
+							<!-- Pick colors -->
+							<h3><?php esc_html_e( 'Pick your primary colors', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'Go to <span class="sandbox-setting-path">Appearance > Customize > Theme options > <a href="%1$s">Theme Layout & Colors</a></span>. We recommend using the same colors as your logo. Don\'t forget to click on <em>Save & Publish</em>.', admin_url( 'customize.php?autofocus[control]=primary_color' ) ); ?></p>
+						</div>
+					</div>
+				</div>
+
+				<div class="welcome-panel-column-container">
+					<div class="welcome-panel-column">
+						<div class="welcome-panel-inner">
+							<!-- Change menu -->
+							<h3><?php esc_html_e( 'Change the main menu', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'Go to <span class="sandbox-setting-path">Appearance > <a href="%1$s">Menus</a></span>. Select the <em>Main Menu</em> from the dropdown at the top and click on the <em>Select</em> button. You will be able to add or remove menu items to fit your wishes. Don\'t forget to click on the <em>Save Menu</em> button. <br>(if you remove a page from the menu, you can still find it in <em>Pages > All Pages</em>)', admin_url( 'nav-menus.php' ) ); ?></p>
+						</div>
+					</div>
+
+		  <div class="welcome-panel-column">
+						<div class="welcome-panel-inner">
+							<!-- Edit content -->
+							<h3><?php esc_html_e( 'Edit website content', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'Go to <span class="sandbox-setting-path">Pages > <a href="%1$s">All Pages</a></span> and edit one of the pages (example: Home page). To edit text and images, hover the mouse over widgets and select <em>edit</em>. Don\'t forget to click on the <em>Update</em> button to save your changes. You can also copy & paste widgets by right clicking on them (works from page to page as well). To make it even easier, select the <em>Live Editor</em> in the small menu above the page.', admin_url( 'edit.php?post_type=page' ) ); ?></p>
+						</div>
+					</div>
+
+					<div class="welcome-panel-column welcome-panel-last">
+						<div class="welcome-panel-inner">
+							<!-- Export content -->
+							<h3><?php esc_html_e( 'Export your website content', 'woocart-defaults' ); ?></h3>
+							<p><?php echo sprintf( 'Go to <span class="sandbox-setting-path">Tools > <a href="%1$s">Export Content</a></span>. There you can export this website content with all the changes you made, so that you will be able to import it on your own WordPress site (on your domain). All you have to do is to <a href="%2$s" target="_blank">purchase the %3$s theme</a> and follow the steps on the <a href="%1$s">Export content</a> page.', admin_url( 'tools.php?page=pt-sandbox-ocde' ), $this->purchase_link( 'wp-steps' ), explode( ' ', ( wp_get_theme() )->get( 'Name' ), 2 )[0] ); ?></p>
+						</div>
+					</div>
+				</div>
+			</div>
+			<?php
+		}
+
+		/**
+		 * For generating the proteus purchase link.
+		 */
+		public function purchase_link( $utm_medium = '' ) {
+			$theme_slug        = get_template();
+			$landing_page_slug = preg_replace( '/-[pc]t$/', '', $theme_slug );
+
+			return sprintf( 'https://proteusthemes.onfastspring.com/%1$s-wp?utm_source=woocart&utm_medium=%2$s&utm_campaign=woocart&utm_content=%1$s', $landing_page_slug, $utm_medium );
+		}
+
+	}
+
+}

--- a/src/classes/traits/proteus.php
+++ b/src/classes/traits/proteus.php
@@ -17,7 +17,7 @@ namespace Niteo\WooCart\Defaults\Extend {
 			$theme = wp_get_theme();
 
 			// Looking for "WoonderShop" name for the theme or parent theme
-			if ( 'WoonderShop' === $theme->name || 'WoonderShop' === $theme->parent_theme ) {
+			if ( 'woondershop-pt' === $theme->template ) {
 				return true;
 			}
 
@@ -134,7 +134,7 @@ namespace Niteo\WooCart\Defaults\Extend {
 			$buttons = [
 				0 => [
 					esc_html__( 'Learn more about WooCart »', 'woocart-defaults' ),
-					'https://woocart.com/',
+					'https://woocart.com/pricing?plan=trial&store_id=' . $_SERVER['STORE_ID'],
 				],
 				1 => [
 					esc_html__( 'Buy the theme for $79', 'woocart-defaults' ),
@@ -159,7 +159,7 @@ namespace Niteo\WooCart\Defaults\Extend {
 					],
 					1 => [
 						esc_html__( 'I would like to keep this hosting.', 'woocart-defaults' ),
-						'https://woocart.com/',
+						'https://woocart.com/pricing?plan=trial&store_id=' . $_SERVER['STORE_ID'],
 					],
 				];
 			}

--- a/tests/AdminDashboardTest.php
+++ b/tests/AdminDashboardTest.php
@@ -148,9 +148,8 @@ class AdminDashboardTest extends TestCase {
 	public function testIsProteusActive() {
 		$dashboard = new AdminDashboard();
 
-		$fake               = new stdClass();
-		$fake->name         = 'WoonderShop';
-		$fake->parent_theme = 'WoonderShop';
+		$fake           = new stdClass();
+		$fake->template = 'woondershop-pt';
 
 		\WP_Mock::userFunction(
 			'wp_get_theme',
@@ -169,9 +168,8 @@ class AdminDashboardTest extends TestCase {
 	public function testIsProteusInactive() {
 		$dashboard = new AdminDashboard();
 
-		$fake               = new stdClass();
-		$fake->name         = 'Astra';
-		$fake->parent_theme = 'Astra';
+		$fake           = new stdClass();
+		$fake->template = 'astra';
 
 		\WP_Mock::userFunction(
 			'wp_get_theme',

--- a/tests/AdminDashboardTest.php
+++ b/tests/AdminDashboardTest.php
@@ -24,6 +24,7 @@ class AdminDashboardTest extends TestCase {
 	 */
 	public function testConstructor() {
 		$dashboard = new AdminDashboard();
+
 		\WP_Mock::expectActionAdded( 'admin_init', [ $dashboard, 'init' ] );
 
 		$dashboard->__construct();
@@ -33,9 +34,12 @@ class AdminDashboardTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
 	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::init
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::is_proteus_active
 	 */
-	public function testInit() {
-		$dashboard = new AdminDashboard();
+	public function testInitProteusInactive() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\AdminDashboard' )->makePartial();
+		$mock->shouldReceive( 'is_proteus_active' )
+				 ->andReturn( false );
 
 		\WP_Mock::userFunction(
 			'remove_action',
@@ -76,9 +80,173 @@ class AdminDashboardTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded( 'welcome_panel', [ $dashboard, 'welcome_panel' ] );
+		\WP_Mock::expectActionAdded( 'welcome_panel', [ $mock, 'welcome_panel' ] );
 
-		$dashboard->init();
+		$mock->init();
 		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::init
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::is_proteus_active
+	 */
+	public function testInitProteusActive() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\AdminDashboard' )->makePartial();
+		$mock->shouldReceive( 'is_proteus_active' )
+				 ->andReturn( true );
+
+		\WP_Mock::userFunction(
+			'remove_action',
+			[
+				'args' =>
+				[
+					'welcome_panel',
+					'wp_welcome_panel',
+				],
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			[
+				'return' => true,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'esc_url',
+			[
+				'return' => true,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'get_admin_url',
+			[
+				'return' => true,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'add_thickbox',
+			[
+				'return' => true,
+			]
+		);
+
+		\WP_Mock::expectActionAdded( 'welcome_panel', [ $mock, 'proteus_welcome_panel' ] );
+
+		$mock->init();
+		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::is_proteus_active
+	 */
+	public function testIsProteusActive() {
+		$dashboard = new AdminDashboard();
+
+		$fake               = new stdClass();
+		$fake->name         = 'WoonderShop';
+		$fake->parent_theme = 'WoonderShop';
+
+		\WP_Mock::userFunction(
+			'wp_get_theme',
+			[
+				'return' => $fake,
+			]
+		);
+
+		$this->assertTrue( $dashboard->is_proteus_active() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::is_proteus_active
+	 */
+	public function testIsProteusInactive() {
+		$dashboard = new AdminDashboard();
+
+		$fake               = new stdClass();
+		$fake->name         = 'Astra';
+		$fake->parent_theme = 'Astra';
+
+		\WP_Mock::userFunction(
+			'wp_get_theme',
+			[
+				'return' => $fake,
+			]
+		);
+
+		$this->assertFalse( $dashboard->is_proteus_active() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::purchase_link
+	 */
+	public function testPurchaseLink() {
+		$dashboard = new AdminDashboard();
+
+		\WP_Mock::userFunction(
+			'get_template',
+			[
+				'return' => 'woondershop',
+			]
+		);
+
+		$this->assertEquals( 'https://proteusthemes.onfastspring.com/woondershop-wp?utm_source=woocart&utm_medium=&utm_campaign=woocart&utm_content=woondershop', $dashboard->purchase_link() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::created_time
+	 */
+	public function testCreatedTime() {
+		$dashboard = new AdminDashboard();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			[
+				'return' => '-1',
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'update_option',
+			[
+				'return' => true,
+			]
+		);
+
+		$dashboard->created_time();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::expiry_time
+	 */
+	public function testExpiryTime() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\AdminDashboard' )->makePartial();
+		$mock->shouldReceive( 'created_time' )
+				 ->andReturn( 1 );
+
+		define( 'DAY_IN_SECONDS', 100 );
+
+		$this->assertEquals( 701, $mock->expiry_time() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::__construct
+	 * @covers \Niteo\WooCart\Defaults\AdminDashboard::date_diff
+	 */
+	public function testDateDiff() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\AdminDashboard' )->makePartial();
+		$mock->shouldReceive( 'expiry_time' )
+				 ->andReturn( 100 );
+
+		$mock->date_diff();
 	}
 }


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/1081

This PR adds a welcome screen to the admin dashboard along with their CTA for buying the theme or continuing with the hosting. Also updates the text copy for our own welcome screen.

How it works:

- The plugin checks for the active theme. If it is `WoonderShop`, we continue with the proteus screen for the dashboard, else our welcome screen.
- An option is added with the timestamp when the proteus instance is created (in `woocart-docker-web`). If the option is missing, an option is created when the screen is loaded for the first time with the validity of 7 days.
- We use that timestamp for calculating the timer for the CTA and update the copy and action buttons as per the number of days remaining for the trial.

And:
- The welcome screen stays independent of the CTA.
- We have different welcome screens (ours and proteus)