### PR TITLE
Add/ignore whitelisted plugins

### DIFF
--- a/src/classes/class-denylist.php
+++ b/src/classes/class-denylist.php
@@ -220,6 +220,7 @@ namespace Niteo\WooCart\Defaults {
 			add_filter( 'plugin_install_action_links', [ &$this, 'disable_install_link' ], 10, 2 );
 			add_filter( 'plugin_action_links', [ &$this, 'disable_activate_link' ], 10, 2 );
 			add_action( 'init', [ &$this, 'get_whitelisted_plugins' ], 10 );
+			add_action( 'init', [ &$this, 'get_denylisted_plugins' ], 10 );
 			add_action( 'activate_plugin', [ &$this, 'disable_activation' ], PHP_INT_MAX, 2 );
 		}
 
@@ -229,6 +230,25 @@ namespace Niteo\WooCart\Defaults {
 		public function get_whitelisted_plugins() {
 			// Fetch whitelist from wp-options
 			$this->whitelist = get_option( 'woocart_whitelisted_plugins', [] );
+		}
+
+		/**
+		 * Get denylisted plugins from the options table.
+		 */
+		public function get_denylisted_plugins() {
+			// Fetch denylist from wp-options
+			$denylist = get_option( 'woocart_denylisted_plugins', [] );
+
+			// Merge it with the list which already exists
+			if ( count( $denylist ) > 0 ) {
+				$new_denylist = array_merge( $this->blacklist, $denylist );
+
+				// Remove dupes
+				$new_denylist = array_unique( $new_denylist );
+
+				// Set $blacklist to the new list
+				$this->blacklist = $new_denylist;
+			}
 		}
 
 		/**

--- a/src/classes/class-denylist.php
+++ b/src/classes/class-denylist.php
@@ -219,8 +219,14 @@ namespace Niteo\WooCart\Defaults {
 
 			add_filter( 'plugin_install_action_links', [ &$this, 'disable_install_link' ], 10, 2 );
 			add_filter( 'plugin_action_links', [ &$this, 'disable_activate_link' ], 10, 2 );
+			add_action( 'init', [ &$this, 'get_whitelisted_plugins' ], 10 );
 			add_action( 'activate_plugin', [ &$this, 'disable_activation' ], PHP_INT_MAX, 2 );
+		}
 
+		/**
+		 * Get whitelisted plugins from the options table.
+		 */
+		public function get_whitelisted_plugins() {
 			// Fetch whitelist from wp-options
 			$this->whitelist = get_option( 'woocart_whitelisted_plugins', [] );
 		}
@@ -379,5 +385,6 @@ namespace Niteo\WooCart\Defaults {
 		}
 
 	}
+
 
 }

--- a/src/classes/class-denylist.php
+++ b/src/classes/class-denylist.php
@@ -203,6 +203,8 @@ namespace Niteo\WooCart\Defaults {
 			'zencache',
 		];
 
+		protected $whitelist = [];
+
 		/**
 		 * Denylist constructor.
 		 */
@@ -218,6 +220,9 @@ namespace Niteo\WooCart\Defaults {
 			add_filter( 'plugin_install_action_links', [ &$this, 'disable_install_link' ], 10, 2 );
 			add_filter( 'plugin_action_links', [ &$this, 'disable_activate_link' ], 10, 2 );
 			add_action( 'activate_plugin', [ &$this, 'disable_activation' ], PHP_INT_MAX, 2 );
+
+			// Fetch whitelist from wp-options
+			$this->whitelist = get_option( 'woocart_whitelisted_plugins', [] );
 		}
 
 		/**
@@ -256,6 +261,9 @@ namespace Niteo\WooCart\Defaults {
 		/**
 		 * Check whether a plugin exists in the list of blacklisted plugins or not.
 		 *
+		 * Also, checks for the on-the-fly whitelisted plugins from wp-options table
+		 * and ignores the plugin denial if the plugin is in the whitelisted plugins array.
+		 *
 		 * @param string $plugin Plugin name to check from the list.
 		 * @return boolean
 		 * @access private
@@ -273,9 +281,11 @@ namespace Niteo\WooCart\Defaults {
 				$_plugin = dirname( $_plugin );
 			}
 
-			foreach ( $this->blacklist as $bad_plugin ) {
-				if ( 0 === strcasecmp( $_plugin, $bad_plugin ) ) {
-					return true;
+			if ( ! in_array( $_plugin, $this->whitelist ) ) {
+				foreach ( $this->blacklist as $bad_plugin ) {
+					if ( 0 === strcasecmp( $_plugin, $bad_plugin ) ) {
+						return true;
+					}
 				}
 			}
 

--- a/tests/DenyListTest.php
+++ b/tests/DenyListTest.php
@@ -29,8 +29,8 @@ class DenyListTest extends TestCase {
 		\WP_Mock::expectFilterAdded( 'plugin_action_links', [ $denylist, 'forced_plugins' ], 10, 4 );
 		\WP_Mock::expectFilterAdded( 'plugin_install_action_links', [ $denylist, 'disable_install_link' ], 10, 2 );
 		\WP_Mock::expectFilterAdded( 'plugin_action_links', [ $denylist, 'disable_activate_link' ], 10, 2 );
-		\WP_Mock::expectActionAdded( 'init', [ $denylist, 'get_whitelisted_plugins' ], 10 );
-		\WP_Mock::expectActionAdded( 'init', [ $denylist, 'get_denylisted_plugins' ], 10 );
+		\WP_Mock::expectActionAdded( 'init', [ $denylist, 'get_allowlist_plugins' ], 10 );
+		\WP_Mock::expectActionAdded( 'init', [ $denylist, 'get_denylist_plugins' ], 10 );
 		\WP_Mock::expectActionAdded( 'activate_plugin', [ $denylist, 'disable_activation' ], PHP_INT_MAX, 2 );
 
 		$denylist->__construct();
@@ -38,9 +38,9 @@ class DenyListTest extends TestCase {
 
 	/**
 	 * @covers \Niteo\WooCart\Defaults\DenyList::__construct
-	 * @covers \Niteo\WooCart\Defaults\DenyList::get_whitelisted_plugins
+	 * @covers \Niteo\WooCart\Defaults\DenyList::get_allowlist_plugins
 	 */
-	public function testGetWhitelistedPlugins() {
+	public function testGetAllowlistPlugins() {
 		$denylist = new DenyList();
 
 		\WP_Mock::userFunction(
@@ -50,14 +50,14 @@ class DenyListTest extends TestCase {
 			]
 		);
 
-		$denylist->get_whitelisted_plugins();
+		$denylist->get_allowlist_plugins();
 	}
 
 	/**
 	 * @covers \Niteo\WooCart\Defaults\DenyList::__construct
-	 * @covers \Niteo\WooCart\Defaults\DenyList::get_denylisted_plugins
+	 * @covers \Niteo\WooCart\Defaults\DenyList::get_denylist_plugins
 	 */
-	public function testGetDenylistedPlugins() {
+	public function testGetDenylistPlugins() {
 		$denylist = new DenyList();
 
 		\WP_Mock::userFunction(
@@ -70,7 +70,7 @@ class DenyListTest extends TestCase {
 			]
 		);
 
-		$denylist->get_denylisted_plugins();
+		$denylist->get_denylist_plugins();
 	}
 
 	/**

--- a/tests/DenyListTest.php
+++ b/tests/DenyListTest.php
@@ -29,10 +29,27 @@ class DenyListTest extends TestCase {
 		\WP_Mock::expectFilterAdded( 'plugin_action_links', [ $denylist, 'forced_plugins' ], 10, 4 );
 		\WP_Mock::expectFilterAdded( 'plugin_install_action_links', [ $denylist, 'disable_install_link' ], 10, 2 );
 		\WP_Mock::expectFilterAdded( 'plugin_action_links', [ $denylist, 'disable_activate_link' ], 10, 2 );
-
+		\WP_Mock::expectActionAdded( 'init', [ $denylist, 'get_whitelisted_plugins' ], 10 );
 		\WP_Mock::expectActionAdded( 'activate_plugin', [ $denylist, 'disable_activation' ], PHP_INT_MAX, 2 );
 
 		$denylist->__construct();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\DenyList::__construct
+	 * @covers \Niteo\WooCart\Defaults\DenyList::get_whitelisted_plugins
+	 */
+	public function testGetWhitelistedPlugins() {
+		$denylist = new DenyList();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			[
+				'return' => true,
+			]
+		);
+
+		$denylist->get_whitelisted_plugins();
 	}
 
 	/**

--- a/tests/DenyListTest.php
+++ b/tests/DenyListTest.php
@@ -30,6 +30,7 @@ class DenyListTest extends TestCase {
 		\WP_Mock::expectFilterAdded( 'plugin_install_action_links', [ $denylist, 'disable_install_link' ], 10, 2 );
 		\WP_Mock::expectFilterAdded( 'plugin_action_links', [ $denylist, 'disable_activate_link' ], 10, 2 );
 		\WP_Mock::expectActionAdded( 'init', [ $denylist, 'get_whitelisted_plugins' ], 10 );
+		\WP_Mock::expectActionAdded( 'init', [ $denylist, 'get_denylisted_plugins' ], 10 );
 		\WP_Mock::expectActionAdded( 'activate_plugin', [ $denylist, 'disable_activation' ], PHP_INT_MAX, 2 );
 
 		$denylist->__construct();
@@ -45,11 +46,31 @@ class DenyListTest extends TestCase {
 		\WP_Mock::userFunction(
 			'get_option',
 			[
-				'return' => true,
+				'return' => [],
 			]
 		);
 
 		$denylist->get_whitelisted_plugins();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\DenyList::__construct
+	 * @covers \Niteo\WooCart\Defaults\DenyList::get_denylisted_plugins
+	 */
+	public function testGetDenylistedPlugins() {
+		$denylist = new DenyList();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			[
+				'return' => [
+					'plugin1',
+					'plugin2',
+				],
+			]
+		);
+
+		$denylist->get_denylisted_plugins();
 	}
 
 	/**


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/1146

First part of the US where the logic to ignore the whitelisted plugins list is added. The next part goes into the `wp-cli-dbtools` repository where the function to denylist/whitelist plugins via CLI is added.