### PR TITLE
Fix woocommerce attributes

### DIFF
--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -89,6 +89,10 @@ namespace Niteo\WooCart\Defaults {
 			// Priority set to -1 so that it runs before anything else.
 			add_action( 'wp_ajax_edit_theme_plugin_file', array( &$this, 'flush_cache' ), PHP_INT_MAX );
 
+			// WooCommerce attributes
+			add_action( 'woocommerce_after_add_attribute_fields', [ &$this, 'flush_cache' ] );
+			add_action( 'woocommerce_after_edit_attribute_fields', [ &$this, 'flush_cache' ] );
+
 			/**
 			 * If FCGI_CACHE_PATH is defined in wp-config.php, use that.
 			 */

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -90,8 +90,8 @@ namespace Niteo\WooCart\Defaults {
 			add_action( 'wp_ajax_edit_theme_plugin_file', array( &$this, 'flush_cache' ), PHP_INT_MAX );
 
 			// WooCommerce attributes
-			add_action( 'woocommerce_after_add_attribute_fields', [ &$this, 'flush_cache' ] );
-			add_action( 'woocommerce_after_edit_attribute_fields', [ &$this, 'flush_cache' ] );
+			add_action( 'woocommerce_after_add_attribute_fields', array( &$this, 'flush_redis_cache' ) );
+			add_action( 'woocommerce_after_edit_attribute_fields', array( &$this, 'flush_redis_cache' ) );
 
 			/**
 			 * If FCGI_CACHE_PATH is defined in wp-config.php, use that.

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -41,6 +41,8 @@ class CacheManagerTest extends TestCase {
 		\WP_Mock::expectActionAdded( 'woocommerce_reduce_order_stock', array( $cache, 'flush_redis_cache' ) );
 		\WP_Mock::expectActionAdded( 'woocommerce_reduce_order_stock', array( $cache, 'flush_fcgi_cache' ) );
 		\WP_Mock::expectActionAdded( 'wp_ajax_edit_theme_plugin_file', array( $cache, 'flush_cache' ), PHP_INT_MAX );
+		\WP_Mock::expectActionAdded( 'woocommerce_after_add_attribute_fields', array( $cache, 'flush_cache' ) );
+		\WP_Mock::expectActionAdded( 'woocommerce_after_edit_attribute_fields', array( $cache, 'flush_cache' ) );
 
 		$cache->__construct();
 	}

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -41,8 +41,8 @@ class CacheManagerTest extends TestCase {
 		\WP_Mock::expectActionAdded( 'woocommerce_reduce_order_stock', array( $cache, 'flush_redis_cache' ) );
 		\WP_Mock::expectActionAdded( 'woocommerce_reduce_order_stock', array( $cache, 'flush_fcgi_cache' ) );
 		\WP_Mock::expectActionAdded( 'wp_ajax_edit_theme_plugin_file', array( $cache, 'flush_cache' ), PHP_INT_MAX );
-		\WP_Mock::expectActionAdded( 'woocommerce_after_add_attribute_fields', array( $cache, 'flush_cache' ) );
-		\WP_Mock::expectActionAdded( 'woocommerce_after_edit_attribute_fields', array( $cache, 'flush_cache' ) );
+		\WP_Mock::expectActionAdded( 'woocommerce_after_add_attribute_fields', array( $cache, 'flush_redis_cache' ) );
+		\WP_Mock::expectActionAdded( 'woocommerce_after_edit_attribute_fields', array( $cache, 'flush_redis_cache' ) );
 
 		$cache->__construct();
 	}


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/1169

Flush cache when the WooCommerce attributes are updated.