### PR TITLE
Set admin cookie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.12.6
+VERSION := 3.13.0
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/class-autologin.php
+++ b/src/classes/class-autologin.php
@@ -106,10 +106,10 @@ namespace Niteo\WooCart\Defaults {
 					// Set cookie with one year expiry
 					@setcookie(
 						'woocart_wp_user',
-						$_SERVER['HTTP_HOST'],
+						$_SERVER['store_id'],
 						time() + 60 * 60 * 24 * 365,
 						'/',
-						$_SERVER['SERVER_NAME'],
+						$_SERVER['HTTP_HOST'],
 						true
 					);
 				}

--- a/src/classes/class-autologin.php
+++ b/src/classes/class-autologin.php
@@ -81,39 +81,39 @@ namespace Niteo\WooCart\Defaults {
 					}
 				}
 			}
-        }
+		}
 
-        /**
-         * Set cookie for the admin which will be used by the backend to show appropriate message
-         * to the admin if the store goes down.
-         */
-        public function set_admin_cookie( $username ) {
-            global $wpdb;
+		/**
+		 * Set cookie for the admin which will be used by the backend to show appropriate message
+		 * to the admin if the store goes down.
+		 */
+		public function set_admin_cookie( $username ) {
+			global $wpdb;
 
-            if ( ! username_exists( $username ) ) {
-                return;
-            }
+			if ( ! username_exists( $username ) ) {
+				return;
+			}
 
-            // Get user info
-            $user = get_user_by( 'login', $username );
-            $role = $wpdb->prefix . 'capabilities';
+			// Get user info
+			$user = get_user_by( 'login', $username );
+			$role = $wpdb->prefix . 'capabilities';
 
-            // Get roles for the user and check if "administrator" role exists
-            $capabilities = $user->$role;
+			// Get roles for the user and check if "administrator" role exists
+			$capabilities = $user->$role;
 
-            foreach ( $capabilities as $role ) {
-                if ( 'administrator' == $role ) {
-                    // Set cookie with one year expiry
-                    setcookie(
-                        'woocart_wp_user',
-                        $_SERVER['HTTP_HOST'],
-                        time() + 60 * 60 * 24 * 365,
-                        '/',
-                        $_SERVER['SERVER_NAME'],
-                        true
-                    );
-                }
-            }
-        }
-    }
+			foreach ( $capabilities as $role ) {
+				if ( 'administrator' == $role ) {
+					// Set cookie with one year expiry
+					setcookie(
+						'woocart_wp_user',
+						$_SERVER['HTTP_HOST'],
+						time() + 60 * 60 * 24 * 365,
+						'/',
+						$_SERVER['SERVER_NAME'],
+						true
+					);
+				}
+			}
+		}
+	}
 }

--- a/src/classes/class-autologin.php
+++ b/src/classes/class-autologin.php
@@ -107,10 +107,13 @@ namespace Niteo\WooCart\Defaults {
 					@setcookie(
 						'woocart_wp_user',
 						$_SERVER['store_id'],
-						time() + 60 * 60 * 24 * 365,
-						'/',
-						$_SERVER['HTTP_HOST'],
-						true
+						array(
+							'expires'  => time() + 60 * 60 * 24 * 365,
+							'path'     => '/',
+							'domain'   => $_SERVER['HTTP_HOST'],
+							'secure'   => true,
+							'samesite' => 'Lax',
+						)
 					);
 				}
 			}

--- a/src/classes/class-autologin.php
+++ b/src/classes/class-autologin.php
@@ -104,7 +104,7 @@ namespace Niteo\WooCart\Defaults {
 			foreach ( $capabilities as $role ) {
 				if ( 'administrator' == $role ) {
 					// Set cookie with one year expiry
-					setcookie(
+					@setcookie(
 						'woocart_wp_user',
 						$_SERVER['HTTP_HOST'],
 						time() + 60 * 60 * 24 * 365,

--- a/tests/AutoLoginTest.php
+++ b/tests/AutoLoginTest.php
@@ -165,4 +165,67 @@ class AutoLoginTest extends TestCase {
 		$result = $login->validate_jwt_token( $token, 'sharedSecret' );
 		$this->assertFalse( $result );
 	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\AutoLogin::__construct
+	 * @covers \Niteo\WooCart\Defaults\AutoLogin::set_admin_cookie
+	 */
+	public function testSetAdminCookie() {
+		global $wpdb;
+
+		$_SERVER['HTTP_HOST']   = 'www.testing.com';
+		$_SERVER['SERVER_NAME'] = 'testing.com';
+
+		$login = new AutoLogin();
+		$wpdb  = new Class() {
+			public $prefix = 'wp_';
+		};
+
+		$user = new Class() {
+			public $wp_capabilities = array(
+				'administrator',
+				'editor',
+			);
+		};
+
+		\WP_Mock::userFunction(
+			'username_exists',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_user_by',
+			array(
+				'args'   => array(
+					'login',
+					'USERNAME',
+				),
+				'times'  => 1,
+				'return' => $user,
+			)
+		);
+
+		$login->set_admin_cookie( 'USERNAME' );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\AutoLogin::__construct
+	 * @covers \Niteo\WooCart\Defaults\AutoLogin::set_admin_cookie
+	 */
+	public function testSetAdminCookieWrongUsername() {
+		$login = new AutoLogin();
+
+		\WP_Mock::userFunction(
+			'username_exists',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$login->set_admin_cookie( 'USERNAME' );
+	}
 }


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/1272

This PR sets a custom cookie for the admin via the `wp_authenticate` hook. The problem I faced with `wp_login` is that the function `current_user_can` is not available for the hook. We need to ensure that the user has admin rights for setting the cookie.
