### PR TITLE
Fix beaver builder cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.14.0
+VERSION := 3.15.0
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -49,6 +49,12 @@ namespace Niteo\WooCart\Defaults {
 		public $redis_credentials = array();
 
 		/**
+		 * Beaver Builder credentials
+		 */
+		protected $flbuilder;
+		protected $flcustomizer;
+
+		/**
 		 * CacheManager constructor.
 		 */
 		public function __construct() {
@@ -112,6 +118,20 @@ namespace Niteo\WooCart\Defaults {
 					'path'   => WP_REDIS_PATH,
 				);
 			}
+		}
+
+		/**
+		 * Set static class for the Beaver Builder plugin (FlBuilderModel).
+		 */
+		public function setFlbuilder( \FLBuilderModel $fl_builder ) {
+			$this->flbuilder = $fl_builder;
+		}
+
+		/**
+		 * Set static class for the Beaver Builder plugin (FlBuilderModel).
+		 */
+		public function setFlcustomizer( \FLCustomizer $fl_customizer ) {
+			$this->flcustomizer = $fl_customizer;
 		}
 
 		/**
@@ -286,13 +306,13 @@ namespace Niteo\WooCart\Defaults {
 		 */
 		public function flush_bb_cache() {
 			// Clear builder cache.
-			if ( class_exists( 'FLBuilderModel' ) && method_exists( 'FLBuilderModel', 'delete_asset_cache_for_all_posts' ) ) {
-				FLBuilderModel::delete_asset_cache_for_all_posts();
+			if ( class_exists( 'FLBuilderModel' ) ) {
+				$this->flbuilder::delete_asset_cache_for_all_posts();
 			}
 
 			// Clear theme cache.
-			if ( class_exists( 'FLCustomizer' ) && method_exists( 'FLCustomizer', 'clear_all_css_cache' ) ) {
-				FLCustomizer::clear_all_css_cache();
+			if ( class_exists( 'FLCustomizer' ) ) {
+				$this->flcustomizer::clear_all_css_cache();
 			}
 		}
 

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -51,8 +51,8 @@ namespace Niteo\WooCart\Defaults {
 		/**
 		 * Beaver Builder credentials
 		 */
-		protected $flbuilder;
-		protected $flcustomizer;
+		protected $fl_builder;
+		protected $fl_customizer;
 
 		/**
 		 * CacheManager constructor.
@@ -124,14 +124,14 @@ namespace Niteo\WooCart\Defaults {
 		 * Set static class for the Beaver Builder plugin (FlBuilderModel).
 		 */
 		public function setFlbuilder( \FLBuilderModel $fl_builder ) {
-			$this->flbuilder = $fl_builder;
+			$this->fl_builder = $fl_builder;
 		}
 
 		/**
 		 * Set static class for the Beaver Builder plugin (FLCustomizer).
 		 */
 		public function setFlcustomizer( \FLCustomizer $fl_customizer ) {
-			$this->flcustomizer = $fl_customizer;
+			$this->fl_customizer = $fl_customizer;
 		}
 
 		/**
@@ -307,12 +307,14 @@ namespace Niteo\WooCart\Defaults {
 		public function flush_bb_cache() {
 			// Clear builder cache.
 			if ( class_exists( 'FLBuilderModel' ) ) {
-				$this->flbuilder::delete_asset_cache_for_all_posts();
+				$this->setFlbuilder( new \FLBuilderModel() );
+				$this->fl_builder::delete_asset_cache_for_all_posts();
 			}
 
 			// Clear theme cache.
 			if ( class_exists( 'FLCustomizer' ) ) {
-				$this->flcustomizer::clear_all_css_cache();
+				$this->setFlcustomizer( new \FLCustomizer() );
+				$this->fl_customizer::clear_all_css_cache();
 			}
 		}
 

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -194,6 +194,9 @@ namespace Niteo\WooCart\Defaults {
 
 			// Flush FCGI cache.
 			$this->flush_fcgi_cache( $this->fcgi_path );
+
+			// Flush Beaver Builder cache.
+			$this->flush_bb_cache();
 		}
 
 		/**
@@ -276,6 +279,21 @@ namespace Niteo\WooCart\Defaults {
 			}
 
 			return $deleted;
+		}
+
+		/**
+		 * Flush cache for Beaver builder.
+		 */
+		public function flush_bb_cache() {
+			// Clear builder cache.
+			if ( class_exists( 'FLBuilderModel' ) && method_exists( 'FLBuilderModel', 'delete_asset_cache_for_all_posts' ) ) {
+				FLBuilderModel::delete_asset_cache_for_all_posts();
+			}
+
+			// Clear theme cache.
+			if ( class_exists( 'FLCustomizer' ) && method_exists( 'FLCustomizer', 'clear_all_css_cache' ) ) {
+				FLCustomizer::clear_all_css_cache();
+			}
 		}
 
 		/**

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -128,7 +128,7 @@ namespace Niteo\WooCart\Defaults {
 		}
 
 		/**
-		 * Set static class for the Beaver Builder plugin (FlBuilderModel).
+		 * Set static class for the Beaver Builder plugin (FLCustomizer).
 		 */
 		public function setFlcustomizer( \FLCustomizer $fl_customizer ) {
 			$this->flcustomizer = $fl_customizer;

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -49,12 +49,6 @@ namespace Niteo\WooCart\Defaults {
 		public $redis_credentials = array();
 
 		/**
-		 * Beaver Builder credentials
-		 */
-		protected $fl_builder;
-		protected $fl_customizer;
-
-		/**
 		 * CacheManager constructor.
 		 */
 		public function __construct() {
@@ -118,20 +112,6 @@ namespace Niteo\WooCart\Defaults {
 					'path'   => WP_REDIS_PATH,
 				);
 			}
-		}
-
-		/**
-		 * Set static class for the Beaver Builder plugin (FlBuilderModel).
-		 */
-		public function setFlbuilder( \FLBuilderModel $fl_builder ) {
-			$this->fl_builder = $fl_builder;
-		}
-
-		/**
-		 * Set static class for the Beaver Builder plugin (FLCustomizer).
-		 */
-		public function setFlcustomizer( \FLCustomizer $fl_customizer ) {
-			$this->fl_customizer = $fl_customizer;
 		}
 
 		/**
@@ -306,15 +286,13 @@ namespace Niteo\WooCart\Defaults {
 		 */
 		public function flush_bb_cache() {
 			// Clear builder cache.
-			if ( class_exists( 'FLBuilderModel' ) ) {
-				$this->setFlbuilder( new \FLBuilderModel() );
-				$this->fl_builder::delete_asset_cache_for_all_posts();
+			if ( class_exists( 'FLBuilderModel' ) && method_exists( 'FLBuilderModel', 'delete_asset_cache_for_all_posts' ) ) {
+				\FLBuilderModel::delete_asset_cache_for_all_posts();
 			}
 
 			// Clear theme cache.
-			if ( class_exists( 'FLCustomizer' ) ) {
-				$this->setFlcustomizer( new \FLCustomizer() );
-				$this->fl_customizer::clear_all_css_cache();
+			if ( class_exists( 'FLCustomizer' ) && method_exists( 'FLCustomizer', 'clear_all_css_cache' ) ) {
+				\FLCustomizer::clear_all_css_cache();
 			}
 		}
 

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -175,6 +175,7 @@ class CacheManagerTest extends TestCase {
 	 * @covers \Niteo\WooCart\Defaults\CacheManager::flush_redis_cache
 	 * @covers \Niteo\WooCart\Defaults\CacheManager::redis_connect
 	 * @covers \Niteo\WooCart\Defaults\CacheManager::flush_fcgi_cache
+	 * @covers \Niteo\WooCart\Defaults\CacheManager::flush_bb_cache
 	 */
 	public function testCheckCacheRequestFlushException() {
 		$cache = new CacheManager();
@@ -314,6 +315,7 @@ class CacheManagerTest extends TestCase {
 	 * @covers \Niteo\WooCart\Defaults\CacheManager::flush_opcache
 	 * @covers \Niteo\WooCart\Defaults\CacheManager::flush_redis_cache
 	 * @covers \Niteo\WooCart\Defaults\CacheManager::flush_fcgi_cache
+	 * @covers \Niteo\WooCart\Defaults\CacheManager::flush_bb_cache
 	 */
 	public function testFlushCache() {
 		$method = self::getMethod( 'flush_cache' );
@@ -326,6 +328,8 @@ class CacheManagerTest extends TestCase {
 		$mock->shouldReceive( 'flush_redis_cache' )
 			->andReturn( true );
 		$mock->shouldReceive( 'flush_fcgi_cache' )
+			->andReturn( true );
+		$mock->shouldReceive( 'flush_bb_cache' )
 			->andReturn( true );
 
 		$method->invokeArgs( $mock, array() );
@@ -411,6 +415,26 @@ class CacheManagerTest extends TestCase {
 			->andReturn( true );
 
 		$method->invokeArgs( $mock, array() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\CacheManager::__construct
+	 * @covers \Niteo\WooCart\Defaults\CacheManager::flush_bb_cache
+	 * @covers \Niteo\WooCart\Defaults\CacheManager::setFlbuilder
+	 * @covers \Niteo\WooCart\Defaults\CacheManager::setFlcustomizer
+	 */
+	public function testFlushBbCache() {
+		$cache = new CacheManager();
+
+		$fl_builder = \Mockery::mock( '\FLBuilderModel' );
+		$fl_builder->shouldReceive( 'delete_asset_cache_for_all_posts' )->once();
+
+		$fl_customizer = \Mockery::mock( '\FLCustomizer' );
+		$fl_customizer->shouldReceive( 'clear_all_css_cache' )->once();
+
+		$cache->setFlbuilder( $fl_builder );
+		$cache->setFlcustomizer( $fl_customizer );
+		$cache->flush_bb_cache();
 	}
 
 	/**

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -420,19 +420,17 @@ class CacheManagerTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\CacheManager::__construct
 	 * @covers \Niteo\WooCart\Defaults\CacheManager::flush_bb_cache
-	 * @covers \Niteo\WooCart\Defaults\CacheManager::setFlbuilder
-	 * @covers \Niteo\WooCart\Defaults\CacheManager::setFlcustomizer
 	 */
 	public function testFlushBbCache() {
-		$mock = \Mockery::mock( '\Niteo\WooCart\Defaults\CacheManager' )->makePartial();
+		$cache = new CacheManager();
 
-		$fl_builder    = \Mockery::mock( 'alias:\FLBuilderModel' )->shouldReceive( 'delete_asset_cache_for_all_posts' );
-		$fl_customizer = \Mockery::mock( 'alias:\FLCustomizer' )->shouldReceive( 'clear_all_css_cache' );
+		$builder = \Mockery::mock( 'alias:\FLBuilderModel' )
+							->shouldReceive( 'delete_asset_cache_for_all_posts' );
 
-		$mock->shouldReceive( 'setFlbuilder' )->with( $fl_builder )->andReturn( true );
-		$mock->shouldReceive( 'setFlcustomizer' )->with( $fl_customizer )->andReturn( true );
+		$customizer = \Mockery::mock( 'alias:\FLCustomizer' )
+							->shouldReceive( 'clear_all_css_cache' );
 
-		$mock->flush_bb_cache();
+		$cache->flush_bb_cache();
 	}
 
 	/**

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -424,17 +424,15 @@ class CacheManagerTest extends TestCase {
 	 * @covers \Niteo\WooCart\Defaults\CacheManager::setFlcustomizer
 	 */
 	public function testFlushBbCache() {
-		$cache = new CacheManager();
+		$mock = \Mockery::mock( '\Niteo\WooCart\Defaults\CacheManager' )->makePartial();
 
-		$fl_builder = \Mockery::mock( '\FLBuilderModel' );
-		$fl_builder->shouldReceive( 'delete_asset_cache_for_all_posts' )->once();
+		$fl_builder    = \Mockery::mock( 'alias:\FLBuilderModel' )->shouldReceive( 'delete_asset_cache_for_all_posts' );
+		$fl_customizer = \Mockery::mock( 'alias:\FLCustomizer' )->shouldReceive( 'clear_all_css_cache' );
 
-		$fl_customizer = \Mockery::mock( '\FLCustomizer' );
-		$fl_customizer->shouldReceive( 'clear_all_css_cache' )->once();
+		$mock->shouldReceive( 'setFlbuilder' )->with( $fl_builder )->andReturn( true );
+		$mock->shouldReceive( 'setFlcustomizer' )->with( $fl_customizer )->andReturn( true );
 
-		$cache->setFlbuilder( $fl_builder );
-		$cache->setFlcustomizer( $fl_customizer );
-		$cache->flush_bb_cache();
+		$mock->flush_bb_cache();
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/niteoweb/woocart/issues/1375

This PR adds the flush cache functionality for `Beaver Builder` to the plugin. Now, on clicking flush cache from the top menu or CLI will also flush the cache for BB plugin if it is installed and active.