### PR TITLE
Fix for calculating the product count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.15.3
+VERSION := 3.15.4
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/class-democleaner.php
+++ b/src/classes/class-democleaner.php
@@ -124,6 +124,8 @@ namespace Niteo\WooCart\Defaults {
 								if ( $result ) {
 									++$this->products_count;
 								}
+							} else {
+								++$this->products_count;
 							}
 						}
 


### PR DESCRIPTION
Resolves https://github.com/niteoweb/woocart/issues/1448

Increase the counter for removed products if the products are not found in the database. This means that they have been removed manually.