### PR TITLE
Plugin search notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.17.0
+VERSION := 3.18.0
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/class-pluginmanager.php
+++ b/src/classes/class-pluginmanager.php
@@ -77,6 +77,10 @@ namespace Niteo\WooCart\Defaults {
 
 			// Show notification on plugin search for specific keywords
 			add_filter( 'plugins_api_args', array( $this, 'search_notification' ), 10, 2 );
+
+			// Remove redis-cache settings link for menu & plugins page
+			add_action( 'admin_menu', array( $this, 'remove_redis_menu' ), PHP_INT_MAX );
+			add_filter( 'plugin_action_links_redis-cache/redis-cache.php', array( &$this, 'remove_redis_plugin_links' ), PHP_INT_MAX );
 		}
 
 		/**
@@ -254,6 +258,28 @@ namespace Niteo\WooCart\Defaults {
 			if ( in_array( $plugin_file, $this->paths ) ) {
 				echo '<tr><td colspan="3" style="background:#fcd670"><strong>' . $plugin_data['Name'] . '</strong> is a required plugin on WooCart and cannot be deactivated.</td></tr>';
 			}
+		}
+
+		/**
+		 * Removes reds-cache submenu page under the settings menu.
+		 */
+		public function remove_redis_menu() {
+			remove_submenu_page( 'options-general.php', 'redis-cache' );
+		}
+
+		/**
+		 * Remove `Settings` link for the redis cache plugin.
+		 *
+		 * @param array  $links Array of links for the plugins
+		 * @param string $file  Name of the main plugin file
+		 *
+		 * @return array
+		 */
+		public function remove_redis_plugin_links( $links ) {
+			// Remove the first link (which is the `Settings` link)
+			unset( $links[0] );
+
+			return $links;
 		}
 
 		/**

--- a/src/classes/class-pluginmanager.php
+++ b/src/classes/class-pluginmanager.php
@@ -18,6 +18,8 @@ namespace Niteo\WooCart\Defaults {
 	 */
 	class PluginManager {
 
+		use Extend\Notifications;
+
 		/**
 		 * List of plugins.
 		 *
@@ -38,6 +40,15 @@ namespace Niteo\WooCart\Defaults {
 		 * @var array
 		 */
 		public $paths = array();
+
+		/**
+		 * @var array
+		 */
+		private $notification = array(
+			'term'    => '',
+			'matches' => false,
+			'message' => '',
+		);
 
 		/**
 		 * PluginManager constructor.
@@ -63,6 +74,9 @@ namespace Niteo\WooCart\Defaults {
 			if ( defined( 'WOOCART_REQUIRED' ) ) {
 				$this->list = WOOCART_REQUIRED;
 			}
+
+			// Show notification on plugin search for specific keywords
+			add_filter( 'plugins_api_args', array( $this, 'search_notification' ), 10, 2 );
 		}
 
 		/**

--- a/src/classes/traits/notifications.php
+++ b/src/classes/traits/notifications.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Notifications on plugin search.
+ */
+
+namespace Niteo\WooCart\Defaults\Extend {
+
+	trait Notifications {
+
+		/**
+		 * Search for keywords in the plugin search query.
+		 */
+		public function search_notification( $action, $args ) {
+			if ( isset( $action->search ) ) {
+				// Plugin search query
+				$this->notification['term'] = strip_tags( $action->search );
+
+				// Check for keywords
+				$filter = array_filter(
+					array(
+						'backup',
+						'duplicate',
+						'restore',
+						'security',
+						'wordfence',
+						'firewall',
+						'cache',
+						'smush',
+						'optimize',
+						'minify',
+						'compress',
+					),
+					array( $this, 'array_match' )
+				);
+
+				if ( $this->notification['matches'] ) {
+					  // Add the right notification message
+					if ( 'backup' === $this->notification['matches'] ) {
+						$this->notification['message'] = esc_html__( 'Warning! You are searching for backup plugins. WooCart strongly advises against installing this type of plugins because it may significantly impact staging creation. Use the Backups tab in the WooCart dashboard instead. Contact support for more information.', 'woocart-defaults' );
+					}
+
+					if ( 'security' === $this->notification['matches'] ) {
+						  $this->notification['message'] = esc_html__( 'Warning! You are searching for security plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing security configuration. Contact support for more information.', 'woocart-defaults' );
+					}
+
+					if ( 'performance' === $this->notification['matches'] ) {
+							  $this->notification['message'] = esc_html__( 'Warning! You are searching for performance plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing configuration and cause performance issues. Contact support for more information.', 'woocart-defaults' );
+					}
+
+					add_action( 'install_plugins_table_header', array( $this, 'add_text' ) );
+				}
+			}
+		}
+
+		/**
+		 * Adds notification text for plugin search queries.
+		 *
+		 * @codeCoverageIgnore
+		 */
+		public function add_text() : void {
+			echo '<div class="widefat">';
+			echo '<p style="width:100%;background:rgba(241,130,141,0.70);padding:0.500rem 4px;">';
+			echo $this->notification['message'];
+			echo '</p>';
+			echo '</div>';
+		}
+
+		/**
+		 * Function to match array of keywords with the search query.
+		 *
+		 * @param array $keyword Keyword array items to look for in the query
+		 * @return bool
+		 */
+		private function array_match( string $keyword ) : bool {
+			if ( strpos( $this->notification['term'], $keyword ) !== false ) {
+				// Backup
+				if ( in_array( $keyword, array( 'backup', 'duplicate', 'restore' ) ) ) {
+					$this->notification['matches'] = 'backup';
+				}
+
+				// Security
+				if ( in_array( $keyword, array( 'security', 'wordfence', 'firewall' ) ) ) {
+					$this->notification['matches'] = 'security';
+				}
+
+				// Performance
+				if ( in_array( $keyword, array( 'cache', 'smush', 'optimize', 'minify', 'compress' ) ) ) {
+					$this->notification['matches'] = 'performance';
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+	}
+
+}

--- a/src/classes/traits/notifications.php
+++ b/src/classes/traits/notifications.php
@@ -10,16 +10,22 @@ namespace Niteo\WooCart\Defaults\Extend {
 
 		/**
 		 * Search for keywords in the plugin search query.
+		 *
+		 * @param object $args Plugin API arguments
+		 * @param string $action The type of information being requested from the Plugin Installation API
+		 *
+		 * @return void
 		 */
-		public function search_notification( $action, $args ) {
-			if ( isset( $action->search ) ) {
+		public function search_notification( object $args, string $action ) : void {
+			if ( isset( $args->search ) ) {
 				// Plugin search query
-				$this->notification['term'] = strip_tags( $action->search );
+				$this->notification['term'] = strip_tags( $args->search );
 
 				// Check for keywords
 				$filter = array_filter(
 					array(
 						'backup',
+						'backwpup',
 						'duplicate',
 						'restore',
 						'security',
@@ -35,17 +41,17 @@ namespace Niteo\WooCart\Defaults\Extend {
 				);
 
 				if ( $this->notification['matches'] ) {
-					  // Add the right notification message
+					// Add the right notification message
 					if ( 'backup' === $this->notification['matches'] ) {
 						$this->notification['message'] = esc_html__( 'Warning! You are searching for backup plugins. WooCart strongly advises against installing this type of plugins because it may significantly impact staging creation. Use the Backups tab in the WooCart dashboard instead. Contact support for more information.', 'woocart-defaults' );
 					}
 
 					if ( 'security' === $this->notification['matches'] ) {
-						  $this->notification['message'] = esc_html__( 'Warning! You are searching for security plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing security configuration. Contact support for more information.', 'woocart-defaults' );
+						$this->notification['message'] = esc_html__( 'Warning! You are searching for security plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing security configuration. Contact support for more information.', 'woocart-defaults' );
 					}
 
 					if ( 'performance' === $this->notification['matches'] ) {
-							  $this->notification['message'] = esc_html__( 'Warning! You are searching for performance plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing configuration and cause performance issues. Contact support for more information.', 'woocart-defaults' );
+							 $this->notification['message'] = esc_html__( 'Warning! You are searching for performance plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing configuration and cause performance issues. Contact support for more information.', 'woocart-defaults' );
 					}
 
 					add_action( 'install_plugins_table_header', array( $this, 'add_text' ) );
@@ -69,7 +75,7 @@ namespace Niteo\WooCart\Defaults\Extend {
 		/**
 		 * Function to match array of keywords with the search query.
 		 *
-		 * @param array $keyword Keyword array items to look for in the query
+		 * @param string $keyword Keyword to match against
 		 * @return bool
 		 */
 		private function array_match( string $keyword ) : bool {

--- a/src/classes/traits/notifications.php
+++ b/src/classes/traits/notifications.php
@@ -22,36 +22,42 @@ namespace Niteo\WooCart\Defaults\Extend {
 				$this->notification['term'] = strip_tags( $args->search );
 
 				// Check for keywords
-				$filter = array_filter(
-					array(
+				$keywords = array(
+					'backup'      => array(
 						'backup',
 						'backwpup',
 						'duplicate',
+					),
+					'security'    => array(
 						'restore',
 						'security',
 						'wordfence',
 						'firewall',
+					),
+					'performance' => array(
 						'cache',
 						'smush',
 						'optimize',
 						'minify',
 						'compress',
 					),
-					array( $this, 'array_match' )
 				);
+
+				// Match for keywords
+				$this->array_match( $keywords );
 
 				if ( $this->notification['matches'] ) {
 					// Add the right notification message
 					if ( 'backup' === $this->notification['matches'] ) {
-						$this->notification['message'] = esc_html__( 'Warning! You are searching for backup plugins. WooCart strongly advises against installing this type of plugins because it may significantly impact staging creation. Use the Backups tab in the WooCart dashboard instead. Contact support for more information.', 'woocart-defaults' );
+						$this->notification['message'] = esc_html__( 'You are searching for backup plugins. WooCart strongly advises against installing this type of plugins because it may significantly impact staging creation. Use the Backups tab in the WooCart dashboard instead. Contact support for more information.', 'woocart-defaults' );
 					}
 
 					if ( 'security' === $this->notification['matches'] ) {
-						$this->notification['message'] = esc_html__( 'Warning! You are searching for security plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing security configuration. Contact support for more information.', 'woocart-defaults' );
+						$this->notification['message'] = esc_html__( 'You are searching for security plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing security configuration. Contact support for more information.', 'woocart-defaults' );
 					}
 
 					if ( 'performance' === $this->notification['matches'] ) {
-							 $this->notification['message'] = esc_html__( 'Warning! You are searching for performance plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing configuration and cause performance issues. Contact support for more information.', 'woocart-defaults' );
+						$this->notification['message'] = esc_html__( 'You are searching for performance plugins. WooCart strongly advises against installing this type of plugins because it can affect the existing configuration and cause performance issues. Contact support for more information.', 'woocart-defaults' );
 					}
 
 					add_action( 'install_plugins_table_header', array( $this, 'add_text' ) );
@@ -65,37 +71,32 @@ namespace Niteo\WooCart\Defaults\Extend {
 		 * @codeCoverageIgnore
 		 */
 		public function add_text() : void {
-			echo '<div class="widefat">';
-			echo '<p style="width:100%;background:rgba(241,130,141,0.70);padding:0.500rem 4px;">';
-			echo $this->notification['message'];
-			echo '</p>';
-			echo '</div>';
+			echo '<div class="notice" style="background: #e3d9f0;
+              border-radius: 8px;
+              border: none;
+              width: 100%;
+              padding: 1em 4px;"><span style="background: orange;
+              border-radius: 5px;
+              color: white;
+              padding: 0.3em;">WARNING</span> <span style="line-height: 22px;
+              font-size: 1.07em;">' . $this->notification['message'] . '</span></div>';
 		}
 
 		/**
 		 * Function to match array of keywords with the search query.
 		 *
-		 * @param string $keyword Keyword to match against
+		 * @param array $keywords Keywords to match against
 		 * @return bool
 		 */
-		private function array_match( string $keyword ) : bool {
-			if ( strpos( $this->notification['term'], $keyword ) !== false ) {
-				// Backup
-				if ( in_array( $keyword, array( 'backup', 'duplicate', 'restore' ) ) ) {
-					$this->notification['matches'] = 'backup';
-				}
+		private function array_match( array $keywords ) : bool {
+			foreach ( $keywords as $key => $value ) {
+				foreach ( $value as $keyword ) {
+					if ( strpos( $this->notification['term'], $keyword ) !== false ) {
+						$this->notification['matches'] = $key;
 
-				// Security
-				if ( in_array( $keyword, array( 'security', 'wordfence', 'firewall' ) ) ) {
-					$this->notification['matches'] = 'security';
+						return true;
+					}
 				}
-
-				// Performance
-				if ( in_array( $keyword, array( 'cache', 'smush', 'optimize', 'minify', 'compress' ) ) ) {
-					$this->notification['matches'] = 'performance';
-				}
-
-				return true;
 			}
 
 			return false;

--- a/src/index.php
+++ b/src/index.php
@@ -33,7 +33,7 @@ namespace Niteo\WooCart {
 
 	if ( class_exists( 'WP_CLI' ) ) {
 		\WP_CLI::add_command( 'wcd', __NAMESPACE__ . '\Defaults\CLI_Command' );
-	} else {
+		// } else {
 		if ( function_exists( 'add_shortcode' ) ) {
 			new Shortcodes();
 		}

--- a/src/index.php
+++ b/src/index.php
@@ -33,7 +33,7 @@ namespace Niteo\WooCart {
 
 	if ( class_exists( 'WP_CLI' ) ) {
 		\WP_CLI::add_command( 'wcd', __NAMESPACE__ . '\Defaults\CLI_Command' );
-		// } else {
+	} else {
 		if ( function_exists( 'add_shortcode' ) ) {
 			new Shortcodes();
 		}

--- a/tests/PluginManagerTest.php
+++ b/tests/PluginManagerTest.php
@@ -26,6 +26,7 @@ class PluginManagerTest extends TestCase {
 		$plugins = new PluginManager();
 
 		\WP_Mock::expectActionAdded( 'init', array( $plugins, 'init' ) );
+		\WP_Mock::expectFilterAdded( 'plugins_api_args', array( $plugins, 'search_notification' ), 10, 2 );
 		define(
 			'WOOCART_REQUIRED',
 			array(
@@ -458,6 +459,66 @@ class PluginManagerTest extends TestCase {
 		$this->assertEmpty( $mock->force_activation() );
 	}
 
+	/**
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::__construct
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::search_notification
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::array_match
+	 */
+	public function testSeachNotificationBackup() {
+		$plugins = new PluginManager();
+		$object  = (object) array(
+			'search' => 'backup',
+		);
+
+		\WP_Mock::expectActionAdded( 'install_plugins_table_header', array( $plugins, 'add_text' ) );
+		$plugins->search_notification( $object, 'query_api' );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::__construct
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::search_notification
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::array_match
+	 */
+	public function testSeachNotificationSecurity() {
+		$plugins = new PluginManager();
+		$object  = (object) array(
+			'search' => 'wordfence',
+		);
+
+		\WP_Mock::expectActionAdded( 'install_plugins_table_header', array( $plugins, 'add_text' ) );
+		$plugins->search_notification( $object, 'query_api' );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::__construct
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::search_notification
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::array_match
+	 */
+	public function testSeachNotificationPerformance() {
+		$plugins = new PluginManager();
+		$object  = (object) array(
+			'search' => 'smush',
+		);
+
+		\WP_Mock::expectActionAdded( 'install_plugins_table_header', array( $plugins, 'add_text' ) );
+		$plugins->search_notification( $object, 'query_api' );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::__construct
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::search_notification
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::array_match
+	 */
+	public function testSeachNotificationNoMatch() {
+		$plugins = new PluginManager();
+		$object  = (object) array(
+			'search' => 'random',
+		);
+
+		\WP_Mock::expectActionNotAdded( 'install_plugins_table_header', array( $plugins, 'add_text' ) );
+		$plugins->search_notification( $object, 'query_api' );
+	}
+
 	protected static function getMethod( $name ) {
 		$class  = new ReflectionClass( 'Niteo\WooCart\Defaults\PluginManager' );
 		$method = $class->getMethod( $name );
@@ -465,5 +526,7 @@ class PluginManagerTest extends TestCase {
 
 		return $method;
 	}
+
+
 
 }

--- a/tests/PluginManagerTest.php
+++ b/tests/PluginManagerTest.php
@@ -27,6 +27,8 @@ class PluginManagerTest extends TestCase {
 
 		\WP_Mock::expectActionAdded( 'init', array( $plugins, 'init' ) );
 		\WP_Mock::expectFilterAdded( 'plugins_api_args', array( $plugins, 'search_notification' ), 10, 2 );
+		\WP_Mock::expectActionAdded( 'admin_menu', array( $plugins, 'remove_redis_menu' ), PHP_INT_MAX );
+		\WP_Mock::expectFilterAdded( 'plugin_action_links_redis-cache/redis-cache.php', array( $plugins, 'remove_redis_plugin_links' ), PHP_INT_MAX );
 		define(
 			'WOOCART_REQUIRED',
 			array(
@@ -517,6 +519,41 @@ class PluginManagerTest extends TestCase {
 
 		\WP_Mock::expectActionNotAdded( 'install_plugins_table_header', array( $plugins, 'add_text' ) );
 		$plugins->search_notification( $object, 'query_api' );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::__construct
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::remove_redis_menu
+	 */
+	public function testRemoveRedisMenu() {
+		$plugins = new PluginManager();
+
+		\WP_Mock::userFunction(
+			'remove_submenu_page',
+			array(
+				'args'   => array(
+					'options-general.php',
+					'redis-cache',
+				),
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$plugins->remove_redis_menu();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::__construct
+	 * @covers \Niteo\WooCart\Defaults\PluginManager::remove_redis_plugin_links
+	 */
+	public function testRemoveRedisPluginLinks() {
+		$plugins = new PluginManager();
+
+		$this->assertEquals(
+			array( 1 => 'deactivate.php' ),
+			$plugins->remove_redis_plugin_links( array( 'settings.php', 'deactivate.php' ) )
+		);
 	}
 
 	protected static function getMethod( $name ) {


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1505
Refs https://github.com/niteoweb/woocart/issues/1662

This PR adds notification on plugin search in the WP admin for specific keywords. It works by displaying the notification above the table pagination. However, this does not works on mobile since WP seems to hideout the class.

Also, links to the settings page for the `redis-cache` plugin have been removed in this PR. They have been removed from the admin menu as well the plugins page.

<img width="1240" alt="Screenshot 2020-06-08 at 9 40 35 PM" src="https://user-images.githubusercontent.com/266324/84062568-21e8e880-a9dd-11ea-9dbb-c07feb243cb2.png">
