### PR TITLE
Support for disabling license check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.18.1
+VERSION := 3.19.0
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/class-cli-command.php
+++ b/src/classes/class-cli-command.php
@@ -368,5 +368,43 @@ namespace Niteo\WooCart\Defaults {
 				WP_CLI::error( $e );
 			}
 		}
+
+		/**
+		 * Toggle blocking HTTP calls for the store.
+		 *
+		 * ## OPTIONS
+		 *
+		 * <status>
+		 * : Block mode status.
+		 * ---
+		 * options:
+		 *   - activate
+		 *   - deactivate
+		 *
+		 * ## EXAMPLES
+		 *
+		 *     wp wcd block_http_calls activate
+		 *
+		 * @codeCoverageIgnore
+		 * @param $args array list of command line arguments.
+		 * @param $assoc_args array of named command line keys.
+		 * @throws WP_CLI\ExitException on wrong command.
+		 */
+		public function block_http_calls( $args, $assoc_args ) {
+			try {
+				list($status) = $args;
+
+				if ( 'activate' === $status ) {
+					update_option( 'woocart_http_status', true );
+				} elseif ( 'deactivate' === $status ) {
+					update_option( 'woocart_http_status', false );
+				}
+
+				WP_CLI::log( sprintf( 'HTTP calls block mode has been %sd.', $status ) );
+			} catch ( \Exception $e ) {
+				WP_CLI::log( 'There was an error processing your request.' );
+				WP_CLI::error( $e );
+			}
+		}
 	}
 }

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Niteo\WooCart\Defaults {
+
+	/**
+	 * Class WooCommerce
+	 *
+	 * @package Niteo\WooCart\Defaults
+	 */
+	class WordPress {
+
+		public function __construct() {
+			add_action( 'init', array( $this, 'http_block_status' ) );
+		}
+
+		/**
+		 * Checks whether to block HTTP calls or not by looking in the
+		 * `wp_options` for the status.
+		 */
+		public function http_block_status() : void {
+			if ( get_option( 'woocart_http_status', false ) ) {
+				add_filter( 'pre_http_request', array( $this, 'http_requests' ), ~PHP_INT_MAX, 3 );
+			}
+		}
+
+		/**
+		 * Check for HTTP requests and block all external ones except for the
+		 * calls made to api.wordpress.org
+		 *
+		 * @param false|array|WP_Error $preempt Whether to preempt an HTTP request's return value. Default false
+		 * @param array                $args HTTP request arguments
+		 * @param string               $url The request URL
+		 */
+		public function http_requests( $preempt, array $args, string $url ) : bool {
+			if ( false !== strpos( $url, 'api.wordpress.org' ) ) {
+				return false;
+			}
+
+			return true;
+		}
+
+	}
+
+}

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -32,7 +32,7 @@ namespace Niteo\WooCart\Defaults {
 		 * @param string               $url The request URL
 		 */
 		public function http_requests( $preempt, array $args, string $url ) : bool {
-			if ( false !== strpos( $url, 'api.wordpress.org' ) ) {
+			if ( false !== strpos( $url, apply_filters( 'woocart_whitelist_http_url', 'api.wordpress.org' ) ) ) {
 				return false;
 			}
 

--- a/src/index.php
+++ b/src/index.php
@@ -30,6 +30,7 @@ namespace Niteo\WooCart {
 	use Niteo\WooCart\Defaults\PluginManager;
 	use Niteo\WooCart\Defaults\Shortcodes;
 	use Niteo\WooCart\Defaults\WooCommerce;
+	use Niteo\WooCart\Defaults\WordPress;
 
 	if ( class_exists( 'WP_CLI' ) ) {
 		\WP_CLI::add_command( 'wcd', __NAMESPACE__ . '\Defaults\CLI_Command' );
@@ -61,6 +62,7 @@ namespace Niteo\WooCart {
 			new PluginManager();
 			new Reporter();
 			new WooCommerce();
+			new WordPress();
 		}
 	}
 }

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Niteo\WooCart\Defaults\WordPress;
+use PHPUnit\Framework\TestCase;
+
+class WordPressTest extends TestCase {
+
+
+	function setUp() {
+		\WP_Mock::setUp();
+	}
+
+	function tearDown() {
+		$this->addToAssertionCount(
+			\Mockery::getContainer()->mockery_getExpectationCount()
+		);
+		\WP_Mock::tearDown();
+		\Mockery::close();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 */
+	public function testConstructor() {
+		$wordpress = new WordPress();
+		\WP_Mock::expectActionAdded( 'init', array( $wordpress, 'http_block_status' ) );
+
+		$wordpress->__construct();
+		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::http_block_status
+	 */
+	public function testHttpBlockStatus() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+		\WP_Mock::expectFilterAdded( 'pre_http_request', array( $wordpress, 'http_requests' ), ~PHP_INT_MAX, 3 );
+
+		$wordpress->http_block_status();
+		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::http_requests
+	 */
+	public function testHttpRequestsTrue() {
+		$wordpress = new WordPress();
+
+		$this->assertTrue( $wordpress->http_requests( false, array(), 'https://randompluginwebsite.com' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::http_requests
+	 */
+	public function testHttpRequestsFalse() {
+		$wordpress = new WordPress();
+
+		$this->assertFalse( $wordpress->http_requests( false, array(), 'https://api.wordpress.org/plugins/woocommerce' ) );
+	}
+
+}


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1462

This PR adds support for disabling licensing check by plugins. All external requests are blocked in this except for the ones originating from `api.wordpress.org`.  This is to ensure WP updates are not affected.