### PR TITLE
Delay running of cronjobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.19.1
+VERSION := 3.20.0
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -62,7 +62,7 @@ namespace Niteo\WooCart\Defaults {
 		 * @return void
 		 */
 		public function control_cronjobs() : void {
-			$timezone = $this->get_store_timezone();
+			$timezone = wp_timezone_string();
 
 			$cron_start = DateTime::createFromFormat( 'H:i', $this->start_time, new DateTimeZone( $timezone ) );
 			$cron_end   = DateTime::createFromFormat( 'H:i', $this->end_time, new DateTimeZone( $timezone ) );
@@ -74,18 +74,6 @@ namespace Niteo\WooCart\Defaults {
 
 			// Remove cronjobs via filter
 			add_filter( 'pre_get_ready_cron_jobs', array( $this, 'empty_cronjobs' ) );
-		}
-
-		/**
-		 * Get store's timezone'.
-		 *
-		 * @return string
-		 */
-		public function get_store_timezone() : string {
-			$store_country = get_option( 'woocommerce_default_country', false );
-
-			// Take first value from the array as few countries have more than one timezone
-			return DateTimeZone::listIdentifiers( DateTimeZone::PER_COUNTRY, $store_country )[0];
 		}
 
 		/**

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -2,6 +2,8 @@
 
 namespace Niteo\WooCart\Defaults {
 
+	use DateTime;
+
 	/**
 	 * Class WooCommerce
 	 *
@@ -9,8 +11,22 @@ namespace Niteo\WooCart\Defaults {
 	 */
 	class WordPress {
 
+		/**
+		 * @var string
+		 */
+		public $start_time = '03:00';
+
+		/**
+		 * @var string
+		 */
+		public $end_time = '04:00';
+
+		/**
+		 * Class constructor.
+		 */
 		public function __construct() {
 			add_action( 'init', array( $this, 'http_block_status' ) );
+			add_action( 'init', array( $this, 'control_cronjobs' ), PHP_INT_MAX );
 		}
 
 		/**
@@ -37,6 +53,42 @@ namespace Niteo\WooCart\Defaults {
 			}
 
 			return true;
+		}
+
+		/**
+		 * Control cronjobs to run at a specific time during a day for the store.
+		 *
+		 * @return void
+		 */
+		public function control_cronjobs() : void {
+			$cron_start = DateTime::createFromFormat( 'H:i', $this->start_time );
+			$cron_end   = DateTime::createFromFormat( 'H:i', $this->end_time );
+			$time_now   = $this->time_now();
+
+			if ( $time_now >= $cron_start && $time_now <= $cron_end ) {
+				return;
+			}
+
+			// Remove cronjobs via filter
+			add_filter( 'pre_get_ready_cron_jobs', array( $this, 'empty_cronjobs' ) );
+		}
+
+		/**
+		 * Returns empty array for cronjobs.
+		 *
+		 * @return array
+		 */
+		public function empty_cronjobs() : array {
+			return array();
+		}
+
+		/**
+		 * Returns DateTime object for current time.
+		 *
+		 * @return object
+		 */
+		public function time_now() : object {
+			return new DateTime();
 		}
 
 	}

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -77,7 +77,14 @@ class WordPressTest extends TestCase {
 	public function testControlCronjobsEmpty() {
 		$mock = \Mockery::mock( '\Niteo\WooCart\Defaults\WordPress' )->makePartial();
 		$mock->shouldReceive( 'time_now' )->andReturn( \Datetime::createFromFormat( 'H:i', '03:30', new \DateTimeZone( 'Europe/Madrid' ) ) );
-		$mock->shouldReceive( 'get_store_timezone' )->andReturn( 'Europe/Madrid' );
+
+		\WP_Mock::userFunction(
+			'wp_timezone_string',
+			array(
+				'times'  => 1,
+				'return' => 'Europe/Madrid',
+			)
+		);
 
 		$mock->start_time = '03:00';
 		$mock->end_time   = '04:00';
@@ -88,12 +95,18 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::control_cronjobs
-	 * @covers \Niteo\WooCart\Defaults\WordPress::get_store_timezone
 	 */
 	public function testControlCronjobsNotEmpty() {
 		$mock = \Mockery::mock( '\Niteo\WooCart\Defaults\WordPress' )->makePartial();
 		$mock->shouldReceive( 'time_now' )->andReturn( \Datetime::createFromFormat( 'H:i', '05:30', new \DateTimeZone( 'Europe/Madrid' ) ) );
-		$mock->shouldReceive( 'get_store_timezone' )->andReturn( 'Europe/Madrid' );
+
+		\WP_Mock::userFunction(
+			'wp_timezone_string',
+			array(
+				'times'  => 1,
+				'return' => 'Europe/Madrid',
+			)
+		);
 
 		$mock->start_time = '03:00';
 		$mock->end_time   = '04:00';
@@ -106,29 +119,7 @@ class WordPressTest extends TestCase {
 
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
-	 * @covers \Niteo\WooCart\Defaults\WordPress::get_store_timezone
-	 */
-	public function testGetStoreTimezone() {
-		$wordpress = new WordPress();
-
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'times'  => 1,
-				'return' => 'IN',
-			)
-		);
-
-		$this->assertEquals(
-			'Asia/Kolkata',
-			$wordpress->get_store_timezone()
-		);
-	}
-
-	/**
-	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::empty_cronjobs
-	 * @covers \Niteo\WooCart\Defaults\WordPress::get_store_timezone
 	 */
 	public function testEmptyCronjobs() {
 		$wordpress = new WordPress();

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -76,7 +76,8 @@ class WordPressTest extends TestCase {
 	 */
 	public function testControlCronjobsEmpty() {
 		$mock = \Mockery::mock( '\Niteo\WooCart\Defaults\WordPress' )->makePartial();
-		$mock->shouldReceive( 'time_now' )->andReturn( \Datetime::createFromFormat( 'H:i', '03:30' ) );
+		$mock->shouldReceive( 'time_now' )->andReturn( \Datetime::createFromFormat( 'H:i', '03:30', new \DateTimeZone( 'Europe/Madrid' ) ) );
+		$mock->shouldReceive( 'get_store_timezone' )->andReturn( 'Europe/Madrid' );
 
 		$mock->start_time = '03:00';
 		$mock->end_time   = '04:00';
@@ -87,10 +88,12 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::control_cronjobs
+	 * @covers \Niteo\WooCart\Defaults\WordPress::get_store_timezone
 	 */
 	public function testControlCronjobsNotEmpty() {
 		$mock = \Mockery::mock( '\Niteo\WooCart\Defaults\WordPress' )->makePartial();
-		$mock->shouldReceive( 'time_now' )->andReturn( \Datetime::createFromFormat( 'H:i', '05:30' ) );
+		$mock->shouldReceive( 'time_now' )->andReturn( \Datetime::createFromFormat( 'H:i', '05:30', new \DateTimeZone( 'Europe/Madrid' ) ) );
+		$mock->shouldReceive( 'get_store_timezone' )->andReturn( 'Europe/Madrid' );
 
 		$mock->start_time = '03:00';
 		$mock->end_time   = '04:00';
@@ -103,7 +106,29 @@ class WordPressTest extends TestCase {
 
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::get_store_timezone
+	 */
+	public function testGetStoreTimezone() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => 'IN',
+			)
+		);
+
+		$this->assertEquals(
+			'Asia/Kolkata',
+			$wordpress->get_store_timezone()
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::empty_cronjobs
+	 * @covers \Niteo\WooCart\Defaults\WordPress::get_store_timezone
 	 */
 	public function testEmptyCronjobs() {
 		$wordpress = new WordPress();
@@ -123,7 +148,7 @@ class WordPressTest extends TestCase {
 
 		$this->assertInstanceOf(
 			'\DateTime',
-			$wordpress->time_now()
+			$wordpress->time_now( 'Europe/Madrid' )
 		);
 	}
 


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1710

This PR makes cronjobs run within a specific window which is currently set to 03:00 - 04:00 am store time. Within this 1 hour window, cronjobs will be allowed to run and clear the backlog.