### PR TITLE
Read-only filesystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.20.0
+VERSION := 3.21.0
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/class-cli-command.php
+++ b/src/classes/class-cli-command.php
@@ -406,5 +406,43 @@ namespace Niteo\WooCart\Defaults {
 				WP_CLI::error( $e );
 			}
 		}
+
+		/**
+		 * Toggle modifying files on disk.
+		 *
+		 * ## OPTIONS
+		 *
+		 * <status>
+		 * : Files mod status.
+		 * ---
+		 * options:
+		 *   - activate
+		 *   - deactivate
+		 *
+		 * ## EXAMPLES
+		 *
+		 *     wp wcd filesystem_lock activate
+		 *
+		 * @codeCoverageIgnore
+		 * @param $args array list of command line arguments.
+		 * @param $assoc_args array of named command line keys.
+		 * @throws WP_CLI\ExitException on wrong command.
+		 */
+		public function filesystem_lock( $args, $assoc_args ) {
+			try {
+				list($status) = $args;
+
+				if ( 'activate' === $status ) {
+					update_option( 'woocart_readonly_filesystem', true );
+				} elseif ( 'deactivate' === $status ) {
+					update_option( 'woocart_readonly_filesystem', false );
+				}
+
+				WP_CLI::log( sprintf( 'Read-only filesystem has been %sd.', $status ) );
+			} catch ( \Exception $e ) {
+				WP_CLI::log( 'There was an error processing your request.' );
+				WP_CLI::error( $e );
+			}
+		}
 	}
 }

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -28,6 +28,7 @@ namespace Niteo\WooCart\Defaults {
 		public function __construct() {
 			add_action( 'init', array( $this, 'http_block_status' ) );
 			add_action( 'init', array( $this, 'control_cronjobs' ), PHP_INT_MAX );
+			add_filter( 'file_mod_allowed', array( $this, 'read_only_filesystem' ), PHP_INT_MAX, 2 );
 		}
 
 		/**
@@ -93,6 +94,20 @@ namespace Niteo\WooCart\Defaults {
 		 */
 		public function time_now( string $timezone ) : object {
 			return new DateTime( 'now', new DateTimeZone( $timezone ) );
+		}
+
+		/**
+		 * Makes the filesystem read-only.
+		 *
+		 * @param bool   $file_mod_allowed Whether file modifications are allowed.
+		 * @param string $context The usage context.
+		 */
+		public function read_only_filesystem( $file_mod_allowed, $context ) {
+			if ( ! get_option( 'woocart_readonly_filesystem', false ) ) {
+				return true;
+			}
+
+			return false;
 		}
 
 	}

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -101,13 +101,11 @@ namespace Niteo\WooCart\Defaults {
 		 *
 		 * @param bool   $file_mod_allowed Whether file modifications are allowed.
 		 * @param string $context The usage context.
+		 *
+		 * @return bool
 		 */
-		public function read_only_filesystem( $file_mod_allowed, $context ) {
-			if ( ! get_option( 'woocart_readonly_filesystem', false ) ) {
-				return true;
-			}
-
-			return false;
+		public function read_only_filesystem( bool $file_mod_allowed, string $context ) : bool {
+			return ! get_option( 'woocart_readonly_filesystem', false );
 		}
 
 	}

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -25,6 +25,7 @@ class WordPressTest extends TestCase {
 		$wordpress = new WordPress();
 		\WP_Mock::expectActionAdded( 'init', array( $wordpress, 'http_block_status' ) );
 		\WP_Mock::expectActionAdded( 'init', array( $wordpress, 'control_cronjobs' ), PHP_INT_MAX );
+		\WP_Mock::expectFilterAdded( 'file_mod_allowed', array( $wordpress, 'read_only_filesystem' ), PHP_INT_MAX, 2 );
 
 		$wordpress->__construct();
 		\WP_Mock::assertHooksAdded();
@@ -141,6 +142,42 @@ class WordPressTest extends TestCase {
 			'\DateTime',
 			$wordpress->time_now( 'Europe/Madrid' )
 		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::read_only_filesystem
+	 */
+	public function testReadOnlyFilesystemTrue() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertTrue( $wordpress->read_only_filesystem( false, 'testing' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::read_only_filesystem
+	 */
+	public function testReadOnlyFilesystemFalse() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertFalse( $wordpress->read_only_filesystem( true, 'testing' ) );
 	}
 
 }


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/1725

This PR adds the CLI option for locking the filesystem. When activated, core updates, updates to plugins & themes, plugin & theme removal won't be available.

Usage:
```
wp wcd filesystem_lock activate/deactivate
```
