### PR TITLE
Fix contact form 7 captcha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.21.0
+VERSION := 3.21.1
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.21.1
+VERSION := 3.22.0
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -28,6 +28,7 @@ namespace Niteo\WooCart\Defaults {
 		public function __construct() {
 			add_action( 'init', array( $this, 'http_block_status' ) );
 			add_action( 'init', array( $this, 'control_cronjobs' ), PHP_INT_MAX );
+			add_action( 'wp_footer', array( $this, 'wpcf7_cache' ), PHP_INT_MAX );
 			add_filter( 'file_mod_allowed', array( $this, 'read_only_filesystem' ), PHP_INT_MAX, 2 );
 		}
 
@@ -106,6 +107,13 @@ namespace Niteo\WooCart\Defaults {
 		 */
 		public function read_only_filesystem( bool $file_mod_allowed, string $context ) : bool {
 			return ! get_option( 'woocart_readonly_filesystem', false );
+		}
+
+		/**
+		 * Disables loading of refill script for Contact Form 7.
+		 */
+		public function wpcf7_cache() : void {
+			echo '<script>wpcf7.cached = 0;</script>';
 		}
 
 	}

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -28,7 +28,9 @@ namespace Niteo\WooCart\Defaults {
 		public function __construct() {
 			add_action( 'init', array( $this, 'http_block_status' ) );
 			add_action( 'init', array( $this, 'control_cronjobs' ), PHP_INT_MAX );
-			add_action( 'wp_footer', array( $this, 'wpcf7_cache' ), PHP_INT_MAX );
+			if ( defined( 'WPCF7_PLUGIN' ) ) {
+				add_action( 'wp_footer', array( $this, 'wpcf7_cache' ), PHP_INT_MAX );
+			}
 			add_filter( 'file_mod_allowed', array( $this, 'read_only_filesystem' ), PHP_INT_MAX, 2 );
 		}
 

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -113,7 +113,7 @@ namespace Niteo\WooCart\Defaults {
 		 * Disables loading of refill script for Contact Form 7.
 		 */
 		public function wpcf7_cache() : void {
-			echo '<script>wpcf7.cached = 0;</script>';
+			echo '<script>if (typeof wpcf7 !== "undefined") { wpcf7.cached = 0; }</script>';
 		}
 
 	}

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -187,7 +187,7 @@ class WordPressTest extends TestCase {
 	public function testWpcf7Cache() {
 		$wordpress = new WordPress();
 
-		$this->expectOutputString( '<script>wpcf7.cached = 0;</script>', $wordpress->wpcf7_cache() );
+		$this->expectOutputString( '<script>if (typeof wpcf7 !== "undefined") { wpcf7.cached = 0; }</script>', $wordpress->wpcf7_cache() );
 	}
 
 }

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -180,4 +180,14 @@ class WordPressTest extends TestCase {
 		$this->assertFalse( $wordpress->read_only_filesystem( true, 'testing' ) );
 	}
 
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::wpcf7_cache
+	 */
+	public function testWpcf7Cache() {
+		$wordpress = new WordPress();
+
+		$this->expectOutputString( '<script>wpcf7.cached = 0;</script>', $wordpress->wpcf7_cache() );
+	}
+
 }

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -25,6 +25,7 @@ class WordPressTest extends TestCase {
 		$wordpress = new WordPress();
 		\WP_Mock::expectActionAdded( 'init', array( $wordpress, 'http_block_status' ) );
 		\WP_Mock::expectActionAdded( 'init', array( $wordpress, 'control_cronjobs' ), PHP_INT_MAX );
+		\WP_Mock::expectActionAdded( 'wp_footer', array( $wordpress, 'wpcf7_cache' ), PHP_INT_MAX );
 		\WP_Mock::expectFilterAdded( 'file_mod_allowed', array( $wordpress, 'read_only_filesystem' ), PHP_INT_MAX, 2 );
 
 		$wordpress->__construct();

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -2,6 +2,7 @@
 
 $root_dir = dirname( dirname( __FILE__ ) );
 define( 'WP_PLUGIN_DIR', "$root_dir/tests/fixtures/" );
+define( 'WPCF7_PLUGIN', 'YES_MOCKED' );
 
 require_once "$root_dir/vendor/autoload.php";
 require_once "$root_dir/src/index.php";


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1752

This PR stops CF7 from loading the `refill` script for contact forms when `WP_CAPTCHA` is set to true. Adding `<script>wpcf7.cached = 0;</script>` to the footer sets the cached option to off.

We are not doing any additional checks here such as checking for the existence/activation of the plugin OR presence of contact form on the page.