### PR TITLE
Update handling of cronjobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.22.0
+VERSION := 3.23.0
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/1802

This PR modifies the logic for controlling cronjobs. Instead of making them run for an hour during the day, now cronjobs will be running as usual.

We will be delaying the execution of cronjobs which are problematic. Similar to denylist, we now have the same implementation for cronjobs.