### PR TITLE
Improve WP cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SRCPATH := $(shell pwd)/src
 ensure: vendor
 vendor: src/vendor
 	composer install --dev
-	composer dump-autoload -a
+	composer dump-autoload -o
 
 
 clover.xml: vendor test
@@ -18,7 +18,7 @@ test: vendor
 
 src/vendor:
 	cd src && composer install
-	cd src && composer dump-autoload -a
+	cd src && composer dump-autoload -o
 
 build: ensure
 	sed -i "s/@##VERSION##@/${VERSION}/" src/index.php
@@ -26,7 +26,7 @@ build: ensure
 	mkdir -p build
 	rm -rf src/vendor
 	cd src && composer install --no-dev
-	cd src && composer dump-autoload -a
+	cd src && composer dump-autoload -o
 	rm -rf src/vendor/symfony/yaml/Tests/
 	rm -rf src/vendor/lcobucci/jwt/test/
 	grep -rl "Autoload" src/vendor/composer | xargs sed -i 's/Composer\\Autoload/NiteoWooCartDefaultsAutoload/g'
@@ -55,8 +55,8 @@ lint: ensure
 	bin/phpcs --standard=WordPress tests --ignore=vendor
 
 psr: src/vendor
-	composer dump-autoload -a
-	cd src && composer dump-autoload -a
+	composer dump-autoload -o
+	cd src && composer dump-autoload -o
 
 i18n:
 	wp i18n make-pot src src/i18n/woocart-defaults.pot

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -99,39 +99,6 @@ namespace Niteo\WooCart\Defaults {
 			if ( defined( 'WP_REDIS_PATH' ) ) {
 				$this->redis_credentials = WP_REDIS_PATH;
 			}
-
-			add_filter( 'script_loader_tag', array( $this, 'buffer_scripts' ), PHP_INT_MAX, 3 );
-			add_filter( 'style_loader_tag', array( $this, 'buffer_styles' ), PHP_INT_MAX, 3 );
-		}
-
-		/**
-		 * Add script tags to array.
-		 *
-		 * @param string $tag    The `<script>` tag for the enqueued script.
-		 * @param string $handle The script's registered handle.
-		 * @param string $src    The script's source URL.
-		 *
-		 * @return string
-		 */
-		public function buffer_scripts( $tag, $handle, $src ) : string {
-			$this->scripts['scripts'][] = $src;
-
-			return $tag;
-		}
-
-		/**
-		 * Add style tags to array.
-		 *
-		 * @param string $tag    The `<script>` tag for the enqueued script.
-		 * @param string $handle The script's registered handle.
-		 * @param string $src    The script's source URL.
-		 *
-		 * @return string
-		 */
-		public function buffer_styles( $tag, $handle, $src ) : string {
-			$this->scripts['styles'][] = $src;
-
-			return $tag;
 		}
 
 		/**

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -34,14 +34,6 @@ namespace Niteo\WooCart\Defaults {
 		public $redis_credentials = '/var/www/cache/redis.sock';
 
 		/**
-		 * @var array
-		 */
-		public $scripts = array(
-			'scripts' => array(),
-			'styles'  => array(),
-		);
-
-		/**
 		 * CacheManager constructor.
 		 */
 		public function __construct() {

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -33,6 +33,14 @@ namespace Niteo\WooCart\Defaults {
 		public $redis_credentials = '/var/www/cache/redis.sock';
 
 		/**
+		 * @var array
+		 */
+		public $scripts = array(
+			'scripts' => array(),
+			'styles'  => array(),
+		);
+
+		/**
 		 * CacheManager constructor.
 		 */
 		public function __construct() {
@@ -91,6 +99,39 @@ namespace Niteo\WooCart\Defaults {
 			if ( defined( 'WP_REDIS_PATH' ) ) {
 				$this->redis_credentials = WP_REDIS_PATH;
 			}
+
+			add_filter( 'script_loader_tag', array( $this, 'buffer_scripts' ), PHP_INT_MAX, 3 );
+			add_filter( 'style_loader_tag', array( $this, 'buffer_styles' ), PHP_INT_MAX, 3 );
+		}
+
+		/**
+		 * Add script tags to array.
+		 *
+		 * @param string $tag    The `<script>` tag for the enqueued script.
+		 * @param string $handle The script's registered handle.
+		 * @param string $src    The script's source URL.
+		 *
+		 * @return string
+		 */
+		public function buffer_scripts( $tag, $handle, $src ) : string {
+			$this->scripts['scripts'][] = $src;
+
+			return $tag;
+		}
+
+		/**
+		 * Add style tags to array.
+		 *
+		 * @param string $tag    The `<script>` tag for the enqueued script.
+		 * @param string $handle The script's registered handle.
+		 * @param string $src    The script's source URL.
+		 *
+		 * @return string
+		 */
+		public function buffer_styles( $tag, $handle, $src ) : string {
+			$this->scripts['styles'][] = $src;
+
+			return $tag;
 		}
 
 		/**

--- a/src/classes/class-cachemanager.php
+++ b/src/classes/class-cachemanager.php
@@ -17,6 +17,7 @@ namespace Niteo\WooCart\Defaults {
 	 */
 	class CacheManager {
 
+		use Extend\NavCache;
 
 		/**
 		 * FCGI Cache path.
@@ -99,6 +100,9 @@ namespace Niteo\WooCart\Defaults {
 			if ( defined( 'WP_REDIS_PATH' ) ) {
 				$this->redis_credentials = WP_REDIS_PATH;
 			}
+
+			// Nav-menu cache
+			add_action( 'init', array( $this, 'nav_init' ) );
 		}
 
 		/**

--- a/src/classes/class-gdpr.php
+++ b/src/classes/class-gdpr.php
@@ -412,8 +412,8 @@ namespace Niteo\WooCart\Defaults {
 		public function scripts() {
 			$plugin_dir = plugin_dir_url( dirname( __FILE__ ) );
 
-			wp_enqueue_style( 'woocart-gdpr', "$plugin_dir/assets/css/front-gdpr.css", array(), Release::Version );
-			wp_enqueue_script( 'woocart-gdpr', "$plugin_dir/assets/js/front-gdpr.js", array(), Release::Version, true );
+			wp_enqueue_style( 'woocart-gdpr', "{$plugin_dir}assets/css/front-gdpr.css", array(), Release::Version );
+			wp_enqueue_script( 'woocart-gdpr', "{$plugin_dir}assets/js/front-gdpr.js", array(), Release::Version, true );
 		}
 
 	}

--- a/src/classes/class-woocommerce.php
+++ b/src/classes/class-woocommerce.php
@@ -9,11 +9,21 @@ namespace Niteo\WooCart\Defaults {
 	 */
 	class WooCommerce {
 
+		/**
+		 * @var array
+		 */
+		private const SMALLER_PLANS = array(
+			'cart',
+			'shop',
+			'dev',
+			'cartv2',
+		);
+
 		public function __construct() {
 			add_filter( 'woocommerce_general_settings', array( &$this, 'general_settings' ) );
 
 			// Disable WooCommerce admin plugin on lower plans
-			add_filter( 'woocommerce_admin_disabled', function(){ return in_array($_SERVER['STORE_PLAN'], ["cart", "shop", "dev", "cartv2"]);});
+			add_filter( 'woocommerce_admin_disabled', array( $this, 'maybe_disable_wc_admin' ) );
 		}
 
 		/**
@@ -43,6 +53,15 @@ namespace Niteo\WooCart\Defaults {
 			}
 
 			return $updated_settings;
+		}
+
+		/**
+		 * Checks for store plan and disables WC admin only for smaller plans.
+		 *
+		 * @return @bool
+		 */
+		public function maybe_disable_wc_admin() : bool {
+			return in_array( $_SERVER['STORE_PLAN'], self::SMALLER_PLANS );
 		}
 
 	}

--- a/src/classes/class-wordpress.php
+++ b/src/classes/class-wordpress.php
@@ -36,6 +36,7 @@ namespace Niteo\WooCart\Defaults {
 		 */
 		public function __construct() {
 			add_action( 'init', array( $this, 'http_block_status' ) );
+			add_action( 'init', array( $this, 'remove_heartbeat' ), PHP_INT_MAX );
 			if ( defined( 'WPCF7_PLUGIN' ) ) {
 				add_action( 'wp_footer', array( $this, 'wpcf7_cache' ), PHP_INT_MAX );
 			}
@@ -51,6 +52,13 @@ namespace Niteo\WooCart\Defaults {
 			if ( get_option( 'woocart_http_status', false ) ) {
 				add_filter( 'pre_http_request', array( $this, 'http_requests' ), ~PHP_INT_MAX, 3 );
 			}
+		}
+
+		/**
+		 * De-register hearbeart script.
+		 */
+		public function remove_heartbeat() : void {
+			wp_deregister_script( 'heartbeat' );
 		}
 
 		/**

--- a/src/classes/traits/navcache.php
+++ b/src/classes/traits/navcache.php
@@ -68,7 +68,7 @@ namespace Niteo\WooCart\Defaults\Extend {
 		 * @return string
 		 */
 		public function get_nav_menu( $nav_menu_html, $args ) {
-			$enabled = $this->_is_enabled( $args );
+			$enabled = $this->_is_enabled();
 
 			if ( $enabled ) {
 				$cache = wp_cache_get( $this->_get_cache_key( $args ), $this->_group );
@@ -88,7 +88,7 @@ namespace Niteo\WooCart\Defaults\Extend {
 		 * @return string
 		 */
 		public function save_nav_menu( $nav_menu_html, $args ) {
-			$enabled = $this->_is_enabled( $args );
+			$enabled = $this->_is_enabled();
 
 			if ( $enabled ) {
 				$key = $this->_get_cache_key( $args );
@@ -145,12 +145,11 @@ namespace Niteo\WooCart\Defaults\Extend {
 		}
 
 		/**
-		 * Check for whitelisted query strings and disable cache if present.
+		 * Check for whitelisted query strings so that we don't disable cache for them.
 		 *
-		 * @param object $args
 		 * @return bool
 		 */
-		private function _is_enabled( $args ) : bool {
+		private function _is_enabled() : bool {
 			if ( array() !== array_diff( array_keys( $_GET ), $this->_whitelisted_query_strings ) ) {
 				return false;
 			}

--- a/src/classes/traits/navcache.php
+++ b/src/classes/traits/navcache.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Cache nav menu.
+ */
+
+namespace Niteo\WooCart\Defaults\Extend {
+
+	trait NavCache {
+
+		/**
+		 * @var string
+		 */
+		private $_group = 'navmenu';
+
+		/**
+		 * @var string
+		 */
+		private $_keylist = 'nav_menu_key_list';
+
+		/**
+		 * @var array
+		 */
+		private $_whitelisted_query_strings = array(
+			// https://support.google.com/searchads/answer/7342044
+			'gclid',
+			'gclsrc',
+
+			// https://www.facebook.com/business/help/330994334179410 "URL in ad can't contain Facebook Click ID" section
+			'fbclid',
+
+			// https://en.wikipedia.org/wiki/UTM_parameters
+			'utm_campaign',
+			'utm_content',
+			'utm_medium',
+			'utm_source',
+			'utm_term',
+		);
+
+		/**
+		 * Initialize caching of nav menu.
+		 *
+		 * @return void
+		 */
+		public function nav_init() : void {
+			add_action( 'save_post', array( $this, 'flush_nav_cache' ) );
+			add_action( 'wp_create_nav_menu', array( $this, 'flush_nav_cache' ) );
+			add_action( 'wp_update_nav_menu', array( $this, 'flush_nav_cache' ) );
+			add_action( 'wp_delete_nav_menu', array( $this, 'flush_nav_cache' ) );
+			add_action( 'split_shared_term', array( $this, 'flush_nav_cache' ) );
+
+			if ( is_user_logged_in() ) {
+				return;
+			}
+
+			if ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE ) {
+				return;
+			}
+
+			add_filter( 'pre_wp_nav_menu', array( $this, 'get_nav_menu' ), PHP_INT_MAX, 2 );
+			add_filter( 'wp_nav_menu', array( $this, 'save_nav_menu' ), PHP_INT_MAX, 2 );
+		}
+
+		/**
+		 * @param string $nav_menu_html
+		 * @param object $args
+		 *
+		 * @return string
+		 */
+		public function get_nav_menu( $nav_menu_html, $args ) {
+			$enabled = $this->_is_enabled( $args );
+
+			if ( $enabled ) {
+				$cache = wp_cache_get( $this->_get_cache_key( $args ), $this->_group );
+
+				if ( $cache ) {
+					return $cache;
+				}
+			}
+
+			return $nav_menu_html;
+		}
+
+		/**
+		 * @param string $nav_menu_html
+		 * @param object $args
+		 *
+		 * @return string
+		 */
+		public function save_nav_menu( $nav_menu_html, $args ) {
+			$enabled = $this->_is_enabled( $args );
+
+			if ( $enabled ) {
+				$key = $this->_get_cache_key( $args );
+				wp_cache_set( $key, $nav_menu_html, $this->_group, DAY_IN_SECONDS );
+				$this->_remember_key( $key );
+			}
+
+			return $nav_menu_html;
+		}
+
+		/**
+		 * Flush nav cache.
+		 *
+		 * @return void
+		 */
+		public function flush_nav_cache() : void {
+			foreach ( $this->_get_all_keys() as $key ) {
+				wp_cache_delete( $key, $this->_group );
+			}
+
+			wp_cache_delete( $this->_keylist, $this->_group );
+		}
+
+		/**
+		 * @param string $key
+		 *
+		 * @return void
+		 */
+		private function _remember_key( $key ) : void {
+			$key_list = wp_cache_get( $this->_keylist, $this->_group );
+
+			if ( $key_list ) {
+				$key_list .= '|' . $key;
+			} else {
+				$key_list = $key;
+			}
+
+			wp_cache_set( $this->_keylist, $key_list, $this->_group, DAY_IN_SECONDS );
+		}
+
+		/**
+		 * Get all cache keys for nav menu.
+		 *
+		 * @return array
+		 */
+		private function _get_all_keys() : array {
+			$key_list = wp_cache_get( $this->_keylist, $this->_group );
+
+			if ( ! $key_list ) {
+				$key_list = '';
+			}
+
+			return explode( '|', $key_list );
+		}
+
+		/**
+		 * Check for whitelisted query strings and disable cache if present.
+		 *
+		 * @param object $args
+		 * @return bool
+		 */
+		private function _is_enabled( $args ) : bool {
+			if ( array() !== array_diff( array_keys( $_GET ), $this->_whitelisted_query_strings ) ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		/**
+		 * Returns a cache key name based on args and time.
+		 *
+		 * @param object $args
+		 * @return string
+		 */
+		private function _get_cache_key( $args ) : string {
+			return md5( wp_json_encode( $args ) . time() );
+		}
+	}
+
+}

--- a/src/classes/traits/navcache.php
+++ b/src/classes/traits/navcache.php
@@ -26,8 +26,11 @@ namespace Niteo\WooCart\Defaults\Extend {
 			'gclid',
 			'gclsrc',
 
-			// https://www.facebook.com/business/help/330994334179410 "URL in ad can't contain Facebook Click ID" section
+			// https://www.facebook.com/business/help/330994334179410
 			'fbclid',
+
+			// FB remarketing ID
+			'rmId',
 
 			// https://en.wikipedia.org/wiki/UTM_parameters
 			'utm_campaign',
@@ -50,6 +53,10 @@ namespace Niteo\WooCart\Defaults\Extend {
 			add_action( 'split_shared_term', array( $this, 'flush_nav_cache' ) );
 
 			if ( is_user_logged_in() ) {
+				return;
+			}
+
+			if ( apply_filters( 'woocart_nav_cache_disabled', false ) ) {
 				return;
 			}
 

--- a/src/classes/traits/navcache.php
+++ b/src/classes/traits/navcache.php
@@ -30,7 +30,7 @@ namespace Niteo\WooCart\Defaults\Extend {
 			'fbclid',
 
 			// FB remarketing ID
-			'rmId',
+			'_rmId',
 
 			// https://en.wikipedia.org/wiki/UTM_parameters
 			'utm_campaign',

--- a/src/composer.json
+++ b/src/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "woocart-defaults",
+  "name": "woocart/defaults",
   "description": "Manage and deploy WordPress WooCommerce configuration changes",
   "keywords": [
     "WordPress",

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -227,7 +227,7 @@ class CacheManagerTest extends TestCase {
 
 		define( 'WP_REDIS_PATH', '/path/to/fake/redis.sock' );
 
-		// $cache->check_cache_request();
+		$cache->check_cache_request();
 	}
 
 	/**
@@ -379,7 +379,7 @@ class CacheManagerTest extends TestCase {
 		$redis->shouldReceive( 'flushAll' )
 			->andReturn( true );
 		$cache = new CacheManager();
-		// $cache->flush_redis_cache();
+		$cache->flush_redis_cache();
 	}
 
 	/**

--- a/tests/WooCommerceTest.php
+++ b/tests/WooCommerceTest.php
@@ -24,6 +24,7 @@ class WooCommerceTest extends TestCase {
 	public function testConstructor() {
 		$woocommerce = new WooCommerce();
 		\WP_Mock::expectFilterAdded( 'woocommerce_general_settings', array( $woocommerce, 'general_settings' ) );
+		\WP_Mock::expectFilterAdded( 'woocommerce_admin_disabled', array( $woocommerce, 'maybe_disable_wc_admin' ) );
 
 		$woocommerce->__construct();
 		\WP_Mock::assertHooksAdded();
@@ -59,6 +60,32 @@ class WooCommerceTest extends TestCase {
 				),
 			)
 		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WooCommerce::__construct
+	 * @covers \Niteo\WooCart\Defaults\WooCommerce::maybe_disable_wc_admin
+	 */
+	public function testDisableWCAdminTrue() {
+		$woocommerce = new WooCommerce();
+
+		// Set to cart plan
+		$_SERVER['STORE_PLAN'] = 'cart';
+
+		$this->assertTrue( $woocommerce->maybe_disable_wc_admin() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WooCommerce::__construct
+	 * @covers \Niteo\WooCart\Defaults\WooCommerce::maybe_disable_wc_admin
+	 */
+	public function testDisableWCAdminFalse() {
+		$woocommerce = new WooCommerce();
+
+		// Set to market plan
+		$_SERVER['STORE_PLAN'] = 'market';
+
+		$this->assertFalse( $woocommerce->maybe_disable_wc_admin() );
 	}
 
 }

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -24,6 +24,7 @@ class WordPressTest extends TestCase {
 	public function testConstructor() {
 		$wordpress = new WordPress();
 		\WP_Mock::expectActionAdded( 'init', array( $wordpress, 'http_block_status' ) );
+		\WP_Mock::expectActionAdded( 'init', array( $wordpress, 'remove_heartbeat' ), PHP_INT_MAX );
 		\WP_Mock::expectActionAdded( 'wp_footer', array( $wordpress, 'wpcf7_cache' ), PHP_INT_MAX );
 		\WP_Mock::expectFilterAdded( 'file_mod_allowed', array( $wordpress, 'read_only_filesystem' ), PHP_INT_MAX, 2 );
 		\WP_Mock::expectFilterAdded( 'pre_reschedule_event', array( $wordpress, 'delay_cronjobs' ), PHP_INT_MAX, 2 );
@@ -50,6 +51,24 @@ class WordPressTest extends TestCase {
 
 		$wordpress->http_block_status();
 		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::remove_heartbeat
+	 */
+	public function testRemoveHeartbeat() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'wp_deregister_script',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->remove_heartbeat() );
 	}
 
 	/**


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1722

Caching `wp_enqueue_scripts` is not possible as the right hooks are missing in WordPress. I tried going with a different approach where we catch all the scripts and styles and then serve them from the cache but the problem lies in detecting the header and footer scripts. So, that didn't work out correctly.

In this pull request, the focus is shifted to caching other areas of the store which can be expensive when served from DB. To avoid that, we will be making the following modifications:

- Caching shortcodes and nav menu
- Heartbeat control
