### PR TITLE
Patch for PHP8

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,12 @@ jobs:
     name: On master or PR
     runs-on: ubuntu-latest
     steps:
+    - name: Check out source code
     - uses: actions/checkout@v2
+    - name: Set up PHP environment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
     - name: Install Dependencies
       run: make install
     - name: Lint

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out source code
-    - uses: actions/checkout@v2
+      uses: actions/checkout@v2
     - name: Set up PHP environment
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
     - name: Install Dependencies
       run: make install
     - name: Lint

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SRCPATH := $(shell pwd)/src
 
 install: vendor
 vendor: src/vendor
-	composer install --dev
+	composer install
 	composer dump-autoload -o
 
 clover.xml: vendor test


### PR DESCRIPTION
This PR switches to PHP v7.4 for running tests and also removes the deprecated `--dev`  tag for the composer as it adds dev packages by default now.