### PR TITLE
Add admin bar notification for https calls block mode

### DIFF
--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -1,0 +1,3 @@
+#wp-admin-bar-wc_http_block {
+  background: #c00 !important;
+}

--- a/src/classes/Dashboard.php
+++ b/src/classes/Dashboard.php
@@ -455,7 +455,7 @@ namespace Niteo\WooCart\Defaults {
 			$plugin_dir = plugin_dir_url( dirname( __FILE__ ) );
 			wp_enqueue_style(
 				'woocart-dashboard',
-				"$plugin_dir/assets/css/dashboard.css",
+				"{$plugin_dir}assets/css/dashboard.css",
 				array(),
 				Release::Version,
 				'all'

--- a/src/classes/WordPress.php
+++ b/src/classes/WordPress.php
@@ -77,9 +77,9 @@ namespace Niteo\WooCart\Defaults {
 				array(
 					'parent' => '',
 					'id'     => 'wc_http_block',
-					'title'  => esc_html__( 'HTTP Block Mode', 'woocart-defaults' ),
+					'title'  => esc_html__( 'Blocking HTTP Calls', 'woocart-defaults' ),
 					'meta'   => array(
-						'title' => esc_html__( 'HTTP Block Mode is active', 'woocart-defaults' ),
+						'title' => esc_html__( 'External HTTP calls are getting blocked', 'woocart-defaults' ),
 					),
 					'href'   => '#',
 				)

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -37,6 +37,24 @@ class WordPressTest extends TestCase {
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::http_block_status
 	 */
+	public function testHttpBlockStatusNotActive() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->http_block_status() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::http_block_status
+	 */
 	public function testHttpBlockStatus() {
 		$wordpress = new WordPress();
 
@@ -51,6 +69,140 @@ class WordPressTest extends TestCase {
 
 		$wordpress->http_block_status();
 		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::block_status_admin_button
+	 */
+	public function testBlockStatusButtonNoAdmin() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->block_status_admin_button( '' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::block_status_admin_button
+	 */
+	public function testBlockStatusButtonNotBar() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'is_admin_bar_showing',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->block_status_admin_button( '' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::block_status_admin_button
+	 */
+	public function testBlockStatusButtonNoOption() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'is_admin_bar_showing',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->block_status_admin_button( '' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::block_status_admin_button
+	 */
+	public function testBlockStatusButtonSuccess() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'is_admin_bar_showing',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'add_query_arg',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_nonce_url',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$admin_bar = new class() {
+			function add_menu( $data ) {
+				// Doing something with it.
+			}
+		};
+
+		$this->assertEmpty( $wordpress->block_status_admin_button( $admin_bar ) );
 	}
 
 	/**
@@ -210,6 +362,198 @@ class WordPressTest extends TestCase {
 		$wordpress = new WordPress();
 
 		$this->expectOutputString( '<script>if (typeof wpcf7 !== "undefined") { wpcf7.cached = 0; }</script>', $wordpress->wpcf7_cache() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::admin_scripts
+	 */
+	public function testAdminScripts() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'wp_enqueue_style',
+			array(
+				'times' => 1,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'plugin_dir_url',
+			array(
+				'times' => 1,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->admin_scripts( '' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 */
+	public function testCheckBlockRequestNoAdmin() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->check_block_request() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 */
+	public function testCheckBlockRequestNoRequest() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->check_block_request() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 */
+	public function testCheckBlockRequestNotCorrect() {
+		$wordpress = new WordPress();
+
+		$_REQUEST['wc_http_block'] = 'not_deactivate';
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'sanitize_key',
+			array(
+				'times'  => 1,
+				'return' => 'not_deactivate',
+			)
+		);
+
+		$this->assertEmpty( $wordpress->check_block_request() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 */
+	public function testCheckBlockRequestFailedAdminReferer() {
+		$wordpress = new WordPress();
+
+		$_REQUEST['wc_http_block'] = 'deactivate';
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'sanitize_key',
+			array(
+				'times'  => 1,
+				'return' => 'deactivate',
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'check_admin_referer',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->check_block_request() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
+	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 */
+	public function testCheckBlockRequestSuccess() {
+		$wordpress = new WordPress();
+
+		$_REQUEST['wc_http_block'] = 'deactivate';
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'sanitize_key',
+			array(
+				'times'  => 1,
+				'return' => 'deactivate',
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'check_admin_referer',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'update_option',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_redirect',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'esc_url_raw',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'remove_query_arg',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->check_block_request() );
 	}
 
 }


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/1954

This adds the notification in the admin bar when the HTTP block mode is enabled.

<img width="656" alt="Screenshot 2021-01-20 at 5 19 37 PM" src="https://user-images.githubusercontent.com/266324/105171038-c8849280-5b43-11eb-8017-621c837cdd72.png">

with an option to turn it off

<img width="292" alt="Screenshot 2021-01-20 at 5 19 05 PM" src="https://user-images.githubusercontent.com/266324/105171079-d33f2780-5b43-11eb-81a0-346e8e3e37dc.png">


