### PR TITLE
Add support for URL override on staging stores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ i18n:
 	msgfmt -o src/i18n/$(PLUGINSLUG)-ro_RO.mo src/i18n/$(PLUGINSLUG)-ro_RO.po
 
 cover: clover.xml
-	bin/coverage-check clover.xml 80
+	bin/coverage-check clover.xml 78
 
 clean:
 	rm -rf vendor/ bin src/vendor/

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ i18n:
 	msgfmt -o src/i18n/$(PLUGINSLUG)-ro_RO.mo src/i18n/$(PLUGINSLUG)-ro_RO.po
 
 cover: clover.xml
-	bin/coverage-check clover.xml 78
+	bin/coverage-check clover.xml 80
 
 clean:
 	rm -rf vendor/ bin src/vendor/

--- a/src/classes/Extend/Dashboard.php
+++ b/src/classes/Extend/Dashboard.php
@@ -59,6 +59,18 @@ namespace Niteo\WooCart\Defaults\Extend {
 			return $_SERVER['STORE_STAGING'] === 'no';
 		}
 
+		/**
+		 * Rewrite URL's if the env variable is set to true.
+		 *
+		 * @return boolean
+		 */
+		public function is_rewrite_urls() : bool {
+			if ( ! isset( $_ENV['WP_REWRITE_URLS'] ) ) {
+				return false;
+			}
+
+			return 'true' === $_ENV['WP_REWRITE_URLS'];
+		}
 
 	}
 

--- a/src/classes/WordPress.php
+++ b/src/classes/WordPress.php
@@ -12,6 +12,8 @@ namespace Niteo\WooCart\Defaults {
 	 */
 	class WordPress {
 
+		use Extend\Dashboard;
+
 		/**
 		 * @var string
 		 */
@@ -44,7 +46,13 @@ namespace Niteo\WooCart\Defaults {
 			add_filter( 'file_mod_allowed', array( $this, 'read_only_filesystem' ), PHP_INT_MAX, 2 );
 			add_filter( 'pre_reschedule_event', array( $this, 'delay_cronjobs' ), PHP_INT_MAX, 2 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
-			add_action( 'admin_init', array( &$this, 'check_block_request' ) );
+			add_action( 'admin_init', array( $this, 'check_block_request' ) );
+
+			// Runs only when WP_REWRITE_URLS is set to true and for staging stores
+			if ( $this->is_rewrite_urls() && $this->is_staging() ) {
+				add_action( 'wp_loaded', array( $this, 'start_buffering' ), ~PHP_INT_MAX );
+				add_action( 'wp_print_footer_scripts', array( $this, 'end_buffering' ), PHP_INT_MAX );
+			}
 		}
 
 		/**
@@ -245,6 +253,46 @@ namespace Niteo\WooCart\Defaults {
 					remove_query_arg( 'wc_http_block' )
 				)
 			);
+		}
+
+		/**
+		 * Starts output buffering for overriding staging URL's.
+		 *
+		 * @return void
+		 * @codeCoverageIgnore
+		 */
+		public function start_buffering() : void {
+			ob_start( array( $this, 'staging_url_override' ) );
+		}
+
+		/**
+		 * Overrides URL's for the staging store.
+		 *
+		 * @param string $buffer Page content as string.
+		 * @return string
+		 */
+		public function staging_url_override( string &$buffer ) : string {
+			// Staging URL
+			if ( isset( $_ENV['DOMAIN'] ) ) {
+				$buffer = str_replace( array( 'http://' . $_ENV['DOMAIN'], 'https://' . $_ENV['DOMAIN'] ), '', $buffer );
+			}
+
+			// Live URL
+			if ( isset( $_ENV['PARENT_DOMAIN'] ) ) {
+				$buffer = str_replace( array( 'http://' . $_ENV['PARENT_DOMAIN'], 'https://' . $_ENV['PARENT_DOMAIN'] ), '', $buffer );
+			}
+
+			return $buffer;
+		}
+
+		/**
+		 * Turn off output buffer.
+		 *
+		 * @return void
+		 * @codeCoverageIgnore
+		 */
+		public function end_buffering() : void {
+			ob_end_flush();
 		}
 
 	}

--- a/src/classes/WordPress.php
+++ b/src/classes/WordPress.php
@@ -51,7 +51,9 @@ namespace Niteo\WooCart\Defaults {
 			// Runs only when WP_REWRITE_URLS is set to true and for staging stores
 			if ( $this->is_rewrite_urls() && $this->is_staging() ) {
 				add_action( 'wp_loaded', array( $this, 'start_buffering' ), ~PHP_INT_MAX );
-				add_action( 'wp_print_footer_scripts', array( $this, 'end_buffering' ), PHP_INT_MAX );
+
+				// End buffer
+				$this->end_buffering();
 			}
 		}
 
@@ -292,7 +294,11 @@ namespace Niteo\WooCart\Defaults {
 		 * @codeCoverageIgnore
 		 */
 		public function end_buffering() : void {
-			ob_end_flush();
+			register_shutdown_function(
+				function() {
+					ob_end_flush();
+				}
+			);
 		}
 
 	}

--- a/tests/DashboardTest.php
+++ b/tests/DashboardTest.php
@@ -71,4 +71,26 @@ class DashboardTest extends TestCase {
 		$dashboard->plugins_loaded();
 		\WP_Mock::assertHooksAdded();
 	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\Dashboard::__construct
+	 * @covers \Niteo\WooCart\Defaults\Dashboard::is_rewrite_urls
+	 */
+	public function testIsRewriteUrlsFalse() {
+		$dashboard = new Dashboard();
+
+		$this->assertFalse( $dashboard->is_rewrite_urls() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\Defaults\Dashboard::__construct
+	 * @covers \Niteo\WooCart\Defaults\Dashboard::is_rewrite_urls
+	 */
+	public function testIsRewriteUrlsTrue() {
+		$dashboard               = new Dashboard();
+		$_ENV['WP_REWRITE_URLS'] = 'true';
+
+		$this->assertTrue( $dashboard->is_rewrite_urls() );
+	}
+
 }

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -49,6 +49,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::http_block_status
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testHttpBlockStatusNotActive() {
 		$wordpress = new WordPress();
@@ -67,6 +69,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::http_block_status
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testHttpBlockStatus() {
 		$wordpress = new WordPress();
@@ -87,6 +91,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::block_status_admin_button
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testBlockStatusButtonNoAdmin() {
 		$wordpress = new WordPress();
@@ -105,6 +111,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::block_status_admin_button
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testBlockStatusButtonNotBar() {
 		$wordpress = new WordPress();
@@ -131,6 +139,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::block_status_admin_button
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testBlockStatusButtonNoOption() {
 		$wordpress = new WordPress();
@@ -165,6 +175,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::block_status_admin_button
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testBlockStatusButtonSuccess() {
 		$wordpress = new WordPress();
@@ -221,6 +233,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::remove_heartbeat
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testRemoveHeartbeat() {
 		$wordpress = new WordPress();
@@ -239,6 +253,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::http_requests
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testHttpRequestsTrue() {
 		$wordpress = new WordPress();
@@ -249,6 +265,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::http_requests
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testHttpRequestsFalse() {
 		$wordpress = new WordPress();
@@ -321,6 +339,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::time_now
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testTimeNow() {
 		$wordpress = new WordPress();
@@ -334,6 +354,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::read_only_filesystem
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testReadOnlyFilesystemTrue() {
 		$wordpress = new WordPress();
@@ -352,6 +374,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::read_only_filesystem
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testReadOnlyFilesystemFalse() {
 		$wordpress = new WordPress();
@@ -370,6 +394,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::wpcf7_cache
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testWpcf7Cache() {
 		$wordpress = new WordPress();
@@ -380,6 +406,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::admin_scripts
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testAdminScripts() {
 		$wordpress = new WordPress();
@@ -404,6 +432,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testCheckBlockRequestNoAdmin() {
 		$wordpress = new WordPress();
@@ -422,6 +452,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testCheckBlockRequestNoRequest() {
 		$wordpress = new WordPress();
@@ -440,6 +472,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testCheckBlockRequestNotCorrect() {
 		$wordpress = new WordPress();
@@ -468,6 +502,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testCheckBlockRequestFailedAdminReferer() {
 		$wordpress = new WordPress();
@@ -504,6 +540,8 @@ class WordPressTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\Defaults\WordPress::__construct
 	 * @covers \Niteo\WooCart\Defaults\WordPress::check_block_request
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_rewrite_urls
+	 * @covers \Niteo\WooCart\Defaults\WordPress::is_staging
 	 */
 	public function testCheckBlockRequestSuccess() {
 		$wordpress = new WordPress();

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -6,11 +6,11 @@ use PHPUnit\Framework\TestCase;
 class WordPressTest extends TestCase {
 
 
-	function setUp() {
+	function setUp() : void {
 		\WP_Mock::setUp();
 	}
 
-	function tearDown() {
+	function tearDown() : void {
 		$this->addToAssertionCount(
 			\Mockery::getContainer()->mockery_getExpectationCount()
 		);
@@ -27,6 +27,7 @@ class WordPressTest extends TestCase {
 			array(
 				'is_staging'      => true,
 				'is_rewrite_urls' => true,
+				'end_buffering'   => true,
 			)
 		);
 
@@ -40,7 +41,6 @@ class WordPressTest extends TestCase {
 		\WP_Mock::expectActionAdded( 'admin_init', array( $wordpress, 'check_block_request' ) );
 
 		\WP_Mock::expectActionAdded( 'wp_loaded', array( $wordpress, 'start_buffering' ), ~PHP_INT_MAX );
-		\WP_Mock::expectActionAdded( 'wp_print_footer_scripts', array( $wordpress, 'end_buffering' ), PHP_INT_MAX );
 
 		$wordpress->__construct();
 		\WP_Mock::assertHooksAdded();


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1975

This PR adds support for overriding URLs on staging store. The staging URL is taken from the `DOMAIN` environment variable.