### PR TITLE
Fix for CF7 refill issue

### DIFF
--- a/src/classes/WordPress.php
+++ b/src/classes/WordPress.php
@@ -40,9 +40,7 @@ namespace Niteo\WooCart\Defaults {
 			add_action( 'admin_bar_menu', array( $this, 'block_status_admin_button' ), 100 );
 			add_action( 'init', array( $this, 'http_block_status' ) );
 			add_action( 'init', array( $this, 'remove_heartbeat' ), PHP_INT_MAX );
-			if ( defined( 'WPCF7_PLUGIN' ) ) {
-				add_action( 'wp_footer', array( $this, 'wpcf7_cache' ), PHP_INT_MAX );
-			}
+			add_action( 'wp_footer', array( $this, 'wpcf7_cache' ), PHP_INT_MAX );
 			add_filter( 'file_mod_allowed', array( $this, 'read_only_filesystem' ), PHP_INT_MAX, 2 );
 			add_filter( 'pre_reschedule_event', array( $this, 'delay_cronjobs' ), PHP_INT_MAX, 2 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
@@ -208,6 +206,10 @@ namespace Niteo\WooCart\Defaults {
 		 * Disables loading of refill script for Contact Form 7.
 		 */
 		public function wpcf7_cache() : void {
+			if ( ! defined( 'WPCF7_PLUGIN' ) ) {
+				return;
+			}
+
 			echo '<script>if (typeof wpcf7 !== "undefined") { wpcf7.cached = 0; }</script>';
 		}
 

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -400,9 +400,22 @@ class WordPressTest extends TestCase {
 	 * @covers ::is_rewrite_urls
 	 * @covers ::is_staging
 	 */
+	public function testWpcf7CacheNoPlugin() {
+		$wordpress = new WordPress();
+
+		$this->assertEmpty( $wordpress->wpcf7_cache() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::wpcf7_cache
+	 * @covers ::is_rewrite_urls
+	 * @covers ::is_staging
+	 */
 	public function testWpcf7Cache() {
 		$wordpress = new WordPress();
 
+		define( 'WPCF7_PLUGIN', 'YES_MOCKED' );
 		$this->expectOutputString( '<script>if (typeof wpcf7 !== "undefined") { wpcf7.cached = 0; }</script>', $wordpress->wpcf7_cache() );
 	}
 

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -2,7 +2,6 @@
 
 $root_dir = dirname( dirname( __FILE__ ) );
 define( 'WP_PLUGIN_DIR', "$root_dir/tests/fixtures/" );
-define( 'WPCF7_PLUGIN', 'YES_MOCKED' );
 
 require_once "$root_dir/vendor/autoload.php";
 require_once "$root_dir/src/index.php";


### PR DESCRIPTION
This PR fixes the issue with CF7 refill script showing when the cache is enabled.

The problem was that the check for `WPCF7_PLUGIN` constant was being done in the constructor and the `mu_plugins` are loaded before regular WP plugins. So, the constant was defined post-loading of the defaults plugin and thus the function was not getting added to the `wp_footer` hook.