### PR TITLE
User cache for stores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ i18n:
 	msgfmt -o src/i18n/$(PLUGINSLUG)-ro_RO.mo src/i18n/$(PLUGINSLUG)-ro_RO.po
 
 cover: clover.xml
-	bin/coverage-check clover.xml 65
+	bin/coverage-check clover.xml 78
 
 clean:
 	rm -rf vendor/ bin src/vendor/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,7 @@
     <coverage includeUncoveredFiles="true"
               processUncoveredFiles="true"
               ignoreDeprecatedCodeUnits="true"
-              disableCodeCoverageIgnore="true">
+              disableCodeCoverageIgnore="false">
         <include>
             <directory suffix=".php">src/classes</directory>
             <directory suffix=".php">src/importers</directory>

--- a/src/classes/UserCache.php
+++ b/src/classes/UserCache.php
@@ -1,0 +1,318 @@
+<?php
+/**
+ * Handles user cache for the store.
+ *
+ * @category   Plugins
+ * @package    WordPress
+ * @subpackage woocart-defaults
+ * @since      3.28.0
+ */
+
+namespace Niteo\WooCart\Defaults;
+
+/**
+ * Class UserCache
+ *
+ * @package Niteo\WooCart\Defaults
+ */
+class UserCache {
+
+	/**
+	 * @var string
+	 */
+	private $_key;
+
+	/**
+	 * @var bool
+	 */
+	private $_is_cacheable = false;
+
+	/**
+	 * @var bool
+	 */
+	private $_cache_exists = false;
+
+	/**
+	 * @var string
+	 */
+	private $_cache_group = 'woocart-user-cache';
+
+	/**
+	 * @var string
+	 */
+	private $_cache;
+
+	/**
+	 * UserCache constructor.
+	 */
+	public function __construct() {
+		add_action( 'muplugins_loaded', array( $this, 'init' ) );
+	}
+
+	/**
+	 * Initialize user cache when the mu-plugins are loaded.
+	 *
+	 * @return void
+	 */
+	public function init() : void {
+		// No cache if user is in the admin panel.
+		if ( \is_admin() ) {
+			return;
+		}
+
+		add_action( 'init', array( $this, 'set_cache_key' ), 10 );
+		add_action( 'init', array( $this, 'is_cacheable' ), 12 );
+		add_action( 'init', array( $this, 'check_cache' ), 15 );
+		add_action( 'init', array( $this, 'maybe_serve_cache' ), 20 );
+		add_action( 'wp_loaded', array( $this, 'start_buffering' ), ~PHP_INT_MAX );
+		add_action( 'shutdown', array( $this, 'register_shutdown' ), ~PHP_INT_MAX );
+	}
+
+	/**
+	 * Sets cache key based on cookie token and current page.
+	 *
+	 * @return void
+	 */
+	public function set_cache_key() : void {
+		$auth_cookie = \wp_parse_auth_cookie( '', 'logged_in' );
+
+		if ( ! $auth_cookie ) {
+			return;
+		}
+
+		if ( ! isset( $auth_cookie['token'] ) ) {
+			return;
+		}
+
+		if ( empty( $auth_cookie['token'] ) ) {
+			return;
+		}
+
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return;
+		}
+
+		$token = \sanitize_text_field( $auth_cookie['token'] );
+		$uri   = \sanitize_text_field( $_SERVER['REQUEST_URI'] );
+
+		$this->_key = hash( 'md5', "{$token}:{$uri}" );
+	}
+
+	/**
+	 * Check if current request should be cached or not.
+	 *
+	 * @return void
+	 */
+	public function is_cacheable() {
+		// Check request type.
+		if ( 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
+			return;
+		}
+
+		// Check for logged-in user.
+		if ( ! \is_user_logged_in() ) {
+			return;
+		}
+
+		// add_to_cart / add-to-cart in URL should be skipped.
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add_to_cart' ) ) {
+			return;
+		}
+
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add-to-cart' ) ) {
+			return;
+		}
+
+		// add_to_wishlist / add-to-wishlist (YITH plugin) in URL should be skipped.
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add_to_wishlist' ) ) {
+			return;
+		}
+
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add-to-wishlist' ) ) {
+			return;
+		}
+
+		$this->_is_cacheable = true;
+	}
+
+	/**
+	 * Check for cache based on user token and page uri.
+	 *
+	 * @return void
+	 */
+	public function check_cache() : void {
+		if ( ! $this->get_is_cacheable() ) {
+			return;
+		}
+
+		if ( empty( $this->get_key() ) ) {
+			return;
+		}
+
+		$this->_cache = \wp_cache_get( $this->get_key(), $this->get_cache_group() );
+
+		if ( ! $this->get_cache() ) {
+			return;
+		}
+
+		// If not HTML, we should probably avoid serving the content.
+		if ( ! $this->is_html( $this->get_cache() ) ) {
+			return;
+		}
+
+		$this->_cache_exists = true;
+	}
+
+	/**
+	 * Serve cache if available.
+	 *
+	 * @return void
+	 */
+	public function maybe_serve_cache() {
+		if ( ! $this->get_cache_exists() ) {
+			return;
+		}
+
+		// Serve cached version.
+		echo $this->get_cache();
+
+		// Terminate page.
+		$this->terminate();
+	}
+
+	/**
+	 * Starts output buffering.
+	 *
+	 * @return void
+	 */
+	public function start_buffering() : void {
+		if ( ! $this->get_is_cacheable() ) {
+			return;
+		}
+
+		ob_start();
+	}
+
+	/**
+	 * Register function to be executed when PHP has finished processing.
+	 *
+	 * @return void
+	 */
+	public function register_shutdown() : void {
+		if ( ! $this->get_is_cacheable() ) {
+			return;
+		}
+
+		// Get page content.
+		$cache = ob_get_contents();
+
+		// Put an end to buffer.
+		$this->end_buffering();
+
+		// Set cache
+		\wp_cache_set(
+			$this->get_key(),
+			$cache,
+			$this->get_cache_group()
+		);
+	}
+
+	/**
+	 * Turn off output buffer.
+	 *
+	 * @return void
+	 * @codeCoverageIgnore
+	 */
+	public function end_buffering() : void {
+		if ( ! ob_get_length() ) {
+			return;
+		}
+
+		/**
+		 * Flushing because we need output. In case of no output, it's better
+		 * to use ob_end_clean();
+		 */
+		ob_end_flush();
+	}
+
+	/**
+	 * Flush cache with key.
+	 *
+	 * @param  string $key Cache key.
+	 * @return bool
+	 */
+	public function flush_cache( $key ) : bool {
+		return \wp_cache_delete( $key, $this->_cache_group );
+	}
+
+	/**
+	 * Tell if the page content is HTML.
+	 *
+	 * @param  string $buffer The buffer content.
+	 * @return bool
+	 */
+	public function is_html( $buffer ) : bool {
+		$found = strpos( substr( $buffer, 0, 100 ), '<html' );
+
+		if ( $found === 0 ) {
+			return true;
+		}
+
+		return (bool) $found;
+	}
+
+	/**
+	 * Returns whether the page can be cached or not.
+	 *
+	 * @return bool
+	 */
+	public function get_is_cacheable() : bool {
+		return $this->_is_cacheable;
+	}
+
+	/**
+	 * Returns cache buffer.
+	 *
+	 * @return null|string
+	 */
+	public function get_cache() {
+		return $this->_cache;
+	}
+
+	/**
+	 * Returns whether cache exists or not.
+	 *
+	 * @return bool
+	 */
+	public function get_cache_exists() : bool {
+		return $this->_cache_exists;
+	}
+
+	/**
+	 * Returns cache key.
+	 *
+	 * @return null|string
+	 */
+	public function get_key() {
+		return $this->_key;
+	}
+
+	/**
+	 * Returns cache group.
+	 *
+	 * @return string
+	 */
+	public function get_cache_group() : string {
+		return $this->_cache_group;
+	}
+
+	/**
+	 * Wrapper around the exit() function.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	protected function terminate() {
+		exit;
+	}
+
+}

--- a/src/classes/UserCache.php
+++ b/src/classes/UserCache.php
@@ -114,21 +114,11 @@ class UserCache {
 			return;
 		}
 
-		// add_to_cart / add-to-cart in URL should be skipped.
-		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add_to_cart' ) ) {
-			return;
-		}
+		// Check for add_to_cart / add
+		if ( ! $this->check_query_strings() ) {
+			// Flush cache.
+			$this->flush_cache( $this->_key );
 
-		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add-to-cart' ) ) {
-			return;
-		}
-
-		// add_to_wishlist / add-to-wishlist (YITH plugin) in URL should be skipped.
-		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add_to_wishlist' ) ) {
-			return;
-		}
-
-		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add-to-wishlist' ) ) {
 			return;
 		}
 
@@ -233,6 +223,33 @@ class UserCache {
 		 * to use ob_end_clean();
 		 */
 		ob_end_flush();
+	}
+
+	/**
+	 * Check query strings for add_to_cart & add_to_wishlist
+	 *
+	 * @return bool
+	 */
+	public function check_query_strings() : bool {
+		// add_to_cart / add-to-cart in URL should be skipped.
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add_to_cart' ) ) {
+			return false;
+		}
+
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add-to-cart' ) ) {
+			return false;
+		}
+
+		// add_to_wishlist / add-to-wishlist (YITH plugin) in URL should be skipped.
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add_to_wishlist' ) ) {
+			return false;
+		}
+
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'add-to-wishlist' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/index.php
+++ b/src/index.php
@@ -29,6 +29,7 @@ namespace Niteo\WooCart {
 	use Niteo\WooCart\Defaults\PluginLogger;
 	use Niteo\WooCart\Defaults\PluginManager;
 	use Niteo\WooCart\Defaults\Shortcodes;
+	use Niteo\WooCart\Defaults\UserCache;
 	use Niteo\WooCart\Defaults\WooCommerce;
 	use Niteo\WooCart\Defaults\WordPress;
 
@@ -61,6 +62,9 @@ namespace Niteo\WooCart {
 			new PluginLogger();
 			new PluginManager();
 			new Reporter();
+			if ( defined( 'USER_CACHE_EXP' ) ) {
+				new UserCache();
+			}
 			new WooCommerce();
 			new WordPress();
 		}

--- a/tests/UserCacheTest.php
+++ b/tests/UserCacheTest.php
@@ -216,6 +216,7 @@ class UserCacheTest extends TestCase {
 	/**
 	 * @covers ::__construct
 	 * @covers ::is_cacheable
+	 * @covers ::check_query_strings
 	 */
 	public function testIsCacheableAddToCartOne() {
 		$usercache = new UserCache();
@@ -232,12 +233,21 @@ class UserCacheTest extends TestCase {
 
 		$_SERVER['REQUEST_URI'] = '/blog-page?add_to_cart=100';
 
+		\WP_Mock::userFunction(
+			'wp_cache_delete',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
 		$this->assertEmpty( $usercache->is_cacheable() );
 	}
 
 	/**
 	 * @covers ::__construct
 	 * @covers ::is_cacheable
+	 * @covers ::check_query_strings
 	 */
 	public function testIsCacheableAddToCartTwo() {
 		$usercache = new UserCache();
@@ -254,12 +264,21 @@ class UserCacheTest extends TestCase {
 
 		$_SERVER['REQUEST_URI'] = '/blog-page?add-to-cart=100';
 
+		\WP_Mock::userFunction(
+			'wp_cache_delete',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
 		$this->assertEmpty( $usercache->is_cacheable() );
 	}
 
 	/**
 	 * @covers ::__construct
 	 * @covers ::is_cacheable
+	 * @covers ::check_query_strings
 	 */
 	public function testIsCacheableAddToWishlistOne() {
 		$usercache = new UserCache();
@@ -276,12 +295,21 @@ class UserCacheTest extends TestCase {
 
 		$_SERVER['REQUEST_URI'] = '/blog-page?add_to_wishlist=100';
 
+		\WP_Mock::userFunction(
+			'wp_cache_delete',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
 		$this->assertEmpty( $usercache->is_cacheable() );
 	}
 
 	/**
 	 * @covers ::__construct
 	 * @covers ::is_cacheable
+	 * @covers ::check_query_strings
 	 */
 	public function testIsCacheableAddToWishlistTwo() {
 		$usercache = new UserCache();
@@ -298,12 +326,21 @@ class UserCacheTest extends TestCase {
 
 		$_SERVER['REQUEST_URI'] = '/blog-page?add-to-wishlist=100';
 
+		\WP_Mock::userFunction(
+			'wp_cache_delete',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
 		$this->assertEmpty( $usercache->is_cacheable() );
 	}
 
 	/**
 	 * @covers ::__construct
 	 * @covers ::is_cacheable
+	 * @covers ::check_query_strings
 	 */
 	public function testIsCacheableSuccess() {
 		$usercache = new UserCache();

--- a/tests/UserCacheTest.php
+++ b/tests/UserCacheTest.php
@@ -1,0 +1,593 @@
+<?php
+
+use Niteo\WooCart\Defaults\UserCache;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Niteo\WooCart\Defaults\UserCache
+ */
+class UserCacheTest extends TestCase {
+
+	function setUp() : void {
+		\WP_Mock::setUp();
+	}
+
+	function tearDown() : void {
+		$this->addToAssertionCount(
+			\Mockery::getContainer()->mockery_getExpectationCount()
+		);
+		\WP_Mock::tearDown();
+		\Mockery::close();
+	}
+
+	/**
+	 * @covers ::__construct
+	 */
+	public function testConstructor() {
+		$usercache = new UserCache();
+
+		\WP_Mock::expectActionAdded( 'muplugins_loaded', array( $usercache, 'init' ) );
+
+		$usercache->__construct();
+		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::init
+	 */
+	public function testInitIsAdmin() {
+		$usercache = new UserCache();
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $usercache->init() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::init
+	 */
+	public function testConstructorNotAdmin() {
+		$usercache = new UserCache();
+
+		\WP_Mock::userFunction(
+			'is_admin',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::expectActionAdded( 'init', array( $usercache, 'set_cache_key' ), 10 );
+		\WP_Mock::expectActionAdded( 'init', array( $usercache, 'is_cacheable' ), 12 );
+		\WP_Mock::expectActionAdded( 'init', array( $usercache, 'check_cache' ), 15 );
+		\WP_Mock::expectActionAdded( 'init', array( $usercache, 'maybe_serve_cache' ), 20 );
+		\WP_Mock::expectActionAdded( 'wp_loaded', array( $usercache, 'start_buffering' ), ~PHP_INT_MAX );
+		\WP_Mock::expectActionAdded( 'shutdown', array( $usercache, 'register_shutdown' ), ~PHP_INT_MAX );
+
+		$usercache->init();
+		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::set_cache_key
+	 */
+	public function testSetCacheKeyNoAuthCookie() {
+		$usercache = new UserCache();
+
+		\WP_Mock::userFunction(
+			'wp_parse_auth_cookie',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $usercache->set_cache_key() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::set_cache_key
+	 */
+	public function testSetCacheKeyInvalidCookieData() {
+		$usercache = new UserCache();
+
+		\WP_Mock::userFunction(
+			'wp_parse_auth_cookie',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $usercache->set_cache_key() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::set_cache_key
+	 */
+	public function testSetCacheKeyEmptyToken() {
+		$usercache = new UserCache();
+
+		\WP_Mock::userFunction(
+			'wp_parse_auth_cookie',
+			array(
+				'times'  => 1,
+				'return' => array(
+					'token' => '',
+				),
+			)
+		);
+
+		$this->assertEmpty( $usercache->set_cache_key() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::set_cache_key
+	 */
+	public function testSetCacheKeyEmptyRequestUri() {
+		$usercache = new UserCache();
+
+		\WP_Mock::userFunction(
+			'wp_parse_auth_cookie',
+			array(
+				'times'  => 1,
+				'return' => array(
+					'token' => 'TOKEN_VALUE',
+				),
+			)
+		);
+
+		$this->assertEmpty( $usercache->set_cache_key() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::set_cache_key
+	 */
+	public function testSetCacheKeySuccess() {
+		$usercache = new UserCache();
+
+		\WP_Mock::userFunction(
+			'wp_parse_auth_cookie',
+			array(
+				'times'  => 1,
+				'return' => array(
+					'token' => 'TOKEN_VALUE',
+				),
+			)
+		);
+
+		$_SERVER['REQUEST_URI'] = '/blog-page';
+
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'times'  => 2,
+				'return' => 'SANITIZED_VALUE',
+			)
+		);
+
+		$this->assertEmpty( $usercache->set_cache_key() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_cacheable
+	 */
+	public function testIsCacheablePostMethod() {
+		$usercache = new UserCache();
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$this->assertEmpty( $usercache->is_cacheable() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_cacheable
+	 */
+	public function testIsCacheableNotLoggedIn() {
+		$usercache = new UserCache();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		\WP_Mock::userFunction(
+			'is_user_logged_in',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $usercache->is_cacheable() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_cacheable
+	 */
+	public function testIsCacheableAddToCartOne() {
+		$usercache = new UserCache();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		\WP_Mock::userFunction(
+			'is_user_logged_in',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$_SERVER['REQUEST_URI'] = '/blog-page?add_to_cart=100';
+
+		$this->assertEmpty( $usercache->is_cacheable() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_cacheable
+	 */
+	public function testIsCacheableAddToCartTwo() {
+		$usercache = new UserCache();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		\WP_Mock::userFunction(
+			'is_user_logged_in',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$_SERVER['REQUEST_URI'] = '/blog-page?add-to-cart=100';
+
+		$this->assertEmpty( $usercache->is_cacheable() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_cacheable
+	 */
+	public function testIsCacheableAddToWishlistOne() {
+		$usercache = new UserCache();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		\WP_Mock::userFunction(
+			'is_user_logged_in',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$_SERVER['REQUEST_URI'] = '/blog-page?add_to_wishlist=100';
+
+		$this->assertEmpty( $usercache->is_cacheable() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_cacheable
+	 */
+	public function testIsCacheableAddToWishlistTwo() {
+		$usercache = new UserCache();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		\WP_Mock::userFunction(
+			'is_user_logged_in',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$_SERVER['REQUEST_URI'] = '/blog-page?add-to-wishlist=100';
+
+		$this->assertEmpty( $usercache->is_cacheable() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_cacheable
+	 */
+	public function testIsCacheableSuccess() {
+		$usercache = new UserCache();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		\WP_Mock::userFunction(
+			'is_user_logged_in',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$_SERVER['REQUEST_URI'] = '/blog-page';
+
+		$this->assertEmpty( $usercache->is_cacheable() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::check_cache
+	 */
+	public function testCheckCacheNotCacheable() {
+		$usercache = new UserCache();
+
+		$this->assertEmpty( $usercache->check_cache() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::check_cache
+	 * @covers ::get_is_cacheable
+	 * @covers ::get_key
+	 */
+	public function testCheckCacheEmptyKey() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\UserCache' )->makePartial();
+		$mock->shouldReceive( 'get_is_cacheable' )->andReturn( true );
+		$mock->shouldReceive( 'get_key' )->andReturn( '' );
+
+		$this->assertEmpty( $mock->check_cache() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::check_cache
+	 * @covers ::get_is_cacheable
+	 * @covers ::get_key
+	 */
+	public function testCheckCacheEmptyCache() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\UserCache' )->makePartial();
+		$mock->shouldReceive( 'get_is_cacheable' )->andReturn( true );
+		$mock->shouldReceive( 'get_key' )->andReturn( 'CACHE_KEY' );
+
+		\WP_Mock::userFunction(
+			'wp_cache_get',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $mock->check_cache() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::check_cache
+	 * @covers ::get_is_cacheable
+	 * @covers ::get_key
+	 */
+	public function testCheckCacheNotHtml() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\UserCache' )->makePartial();
+		$mock->shouldReceive( 'get_is_cacheable' )->andReturn( true );
+		$mock->shouldReceive( 'get_key' )->andReturn( 'CACHE_KEY' );
+
+		\WP_Mock::userFunction(
+			'wp_cache_get',
+			array(
+				'times'  => 1,
+				'return' => 'NOT HTML CONTENT',
+			)
+		);
+
+		$this->assertEmpty( $mock->check_cache() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::check_cache
+	 * @covers ::get_is_cacheable
+	 * @covers ::get_key
+	 */
+	public function testCheckCacheSuccess() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\UserCache' )->makePartial();
+		$mock->shouldReceive( 'get_is_cacheable' )->andReturn( true );
+		$mock->shouldReceive( 'get_key' )->andReturn( 'CACHE_KEY' );
+
+		\WP_Mock::userFunction(
+			'wp_cache_get',
+			array(
+				'times'  => 1,
+				'return' => '<html>SOME CONTENT</html>',
+			)
+		);
+
+		$this->assertEmpty( $mock->check_cache() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::maybe_serve_cache
+	 * @covers ::get_cache_exists
+	 */
+	public function testMaybeServeCache() {
+		$usercache = new UserCache();
+
+		$this->assertEmpty( $usercache->maybe_serve_cache() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::check_cache
+	 * @covers ::get_cache_exists
+	 * @covers ::get_cache
+	 * @covers ::terminate
+	 */
+	public function testMaybeServeCacheExists() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\UserCache' )->makePartial()->shouldAllowMockingProtectedMethods();
+		$mock->shouldReceive( 'get_cache_exists' )->andReturn( true );
+		$mock->shouldReceive( 'get_cache' )->andReturn( 'CACHED CONTENT' );
+		$mock->shouldReceive( 'terminate' )->andReturn( true );
+
+		$mock->maybe_serve_cache();
+		$this->expectOutputString( 'CACHED CONTENT' );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::start_buffering
+	 */
+	public function testStartBufferingNotCacheable() {
+		$usercache = new UserCache();
+
+		$this->assertEmpty( $usercache->start_buffering() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::start_buffering
+	 */
+	public function testStartBufferingIsCacheable() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\UserCache' )->makePartial();
+		$mock->shouldReceive( 'get_is_cacheable' )->andReturn( true );
+
+		$this->assertEmpty( $mock->start_buffering() );
+		ob_end_flush();
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::get_is_cacheable
+	 */
+	public function testIsCacheable() {
+		$usercache = new UserCache();
+
+		$this->assertFalse( $usercache->get_is_cacheable() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::register_shutdown
+	 */
+	public function testRegisterShutdownNotCacheable() {
+		$usercache = new UserCache();
+
+		$this->assertEmpty( $usercache->register_shutdown() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::register_shutdown
+	 * @covers ::get_is_cacheable
+	 */
+	public function testRegisterShutdownSuccess() {
+		$mock = \Mockery::mock( 'Niteo\WooCart\Defaults\UserCache' )->shouldAllowMockingProtectedMethods()->makePartial();
+		$mock->shouldReceive( 'get_is_cacheable' )->andReturn( true );
+		$mock->shouldReceive( 'terminate' )->andReturn( true );
+
+		\WP_Mock::userFunction(
+			'wp_cache_set',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $mock->register_shutdown() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::flush_cache
+	 */
+	public function testFlushCacheTrue() {
+		$usercache = new UserCache();
+
+		\WP_Mock::userFunction(
+			'wp_cache_delete',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertTrue( $usercache->flush_cache( 'KEY' ) );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::flush_cache
+	 */
+	public function testFlushCacheFalse() {
+		$usercache = new UserCache();
+
+		\WP_Mock::userFunction(
+			'wp_cache_delete',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertFalse( $usercache->flush_cache( 'KEY' ) );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_html
+	 */
+	public function testIsHtmlTrue() {
+		$usercache = new UserCache();
+
+		$this->assertTrue( $usercache->is_html( '<html>HTML CONTENT</html>' ) );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_html
+	 */
+	public function testIsHtmlFalse() {
+		$usercache = new UserCache();
+
+		$this->assertFalse( $usercache->is_html( 'NOT AN HTML CONTENT' ) );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::get_cache
+	 */
+	public function testGetCache() {
+		$usercache = new UserCache();
+
+		$this->assertEmpty( $usercache->get_cache() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::get_key
+	 */
+	public function testGetKey() {
+		$usercache = new UserCache();
+
+		$this->assertEmpty( $usercache->get_key() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::get_cache_group
+	 */
+	public function testGetCacheGroup() {
+		$usercache = new UserCache();
+
+		$this->assertEquals( 'woocart-user-cache', $usercache->get_cache_group() );
+	}
+
+}


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1955

This PR adds support for user cache in the plugin. The cache works for logged-in users only and the token is taken from the `logged_in` cookie.

To-do:

- [x] Serve cache to the user if it exists
- [x] Flush cache for the page on POST request or with `add_to_cart` GET request
- [x] Add support for popular plugins such as YITH Wishlist etc which uses GET request for adding items to wishlist
- [ ] Test results
