### PR TITLE
Fix denylist for themes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.28.0
+VERSION := 3.28.1
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/Extend/ThemesDenylist.php
+++ b/src/classes/Extend/ThemesDenylist.php
@@ -16,6 +16,11 @@ trait ThemesDenylist {
 	public function add_denylist_theme_notice() : void {
 		$current_theme = \wp_get_theme();
 
+		// Check for theme.
+		if ( ! in_array( $current_theme->get( 'Name' ), $this->themes_denylist ) ) {
+			return;
+		}
+
 		$message = sprintf(
 			esc_html__( '%1$s theme has been shown to have poor performance. We recommend switching to a different theme.', 'woocart-defaults' ),
 			"<strong>{$current_theme->get( 'Name' )}</strong>"

--- a/src/classes/Extend/ThemesDenylist.php
+++ b/src/classes/Extend/ThemesDenylist.php
@@ -22,14 +22,20 @@ trait ThemesDenylist {
 		}
 
 		$message = sprintf(
-			esc_html__( '%1$s theme has been shown to have poor performance. We recommend switching to a different theme.', 'woocart-defaults' ),
-			"<strong>{$current_theme->get( 'Name' )}</strong>"
+			esc_html__( '%1$s theme %2$shas been shown to have poor performance%3$s. We recommend switching to a different theme.', 'woocart-defaults' ),
+			"<strong>{$current_theme->get( 'Name' )}</strong>",
+			'<a href="https://woocart.com/blog/fastest-woocommerce-theme" target="_blank">',
+			'</a>'
 		);
 
 		echo '<div class="error">';
 		echo '<p>' . \wp_kses(
 			$message,
 			array(
+				'a'      => array(
+					'href'   => array(),
+					'target' => array(),
+				),
 				'strong' => array(),
 			)
 		) . '</p>';

--- a/tests/DenyListTest.php
+++ b/tests/DenyListTest.php
@@ -314,11 +314,37 @@ class DenyListTest extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::add_denylist_theme_notice
 	 */
+	public function testAddDenylistThemeNoticeFalse() {
+		$denylist = new DenyList();
+
+		$theme_object = new class() {
+			public $name = 'Astra';
+
+			public function get( $identifier ) {
+				return $this->name;
+			}
+		};
+
+		\WP_Mock::userFunction(
+			'wp_get_theme',
+			array(
+				'times'  => 1,
+				'return' => $theme_object,
+			)
+		);
+
+		$this->assertEmpty( $denylist->add_denylist_theme_notice() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::add_denylist_theme_notice
+	 */
 	public function testAddDenylistThemeNotice() {
 		$denylist = new DenyList();
 
 		$theme_object = new class() {
-			public $name = 'Neve';
+			public $name = 'Woodmart';
 
 			public function get( $identifier ) {
 				return $this->name;
@@ -337,13 +363,13 @@ class DenyListTest extends TestCase {
 			'wp_kses',
 			array(
 				'times'  => 1,
-				'return' => 'Neve theme has been denylisted on WooCart because of poor performance. We recommend switching to a different theme.',
+				'return' => 'Woodmart theme has been denylisted on WooCart because of poor performance. We recommend switching to a different theme.',
 			)
 		);
 
 		$denylist->add_denylist_theme_notice();
 		$this->expectOutputString(
-			'<div class="error"><p>Neve theme has been denylisted on WooCart because of poor performance. We recommend switching to a different theme.</p></div>'
+			'<div class="error"><p>Woodmart theme has been denylisted on WooCart because of poor performance. We recommend switching to a different theme.</p></div>'
 		);
 	}
 


### PR DESCRIPTION
In the previous PR, I made a mistake.

It didn't have the check for the denylisted themes and so would render message for every theme. This has been corrected now.

<img width="1062" alt="Screenshot 2021-03-22 at 7 55 30 PM" src="https://user-images.githubusercontent.com/266324/112005613-ede44b80-8b48-11eb-9209-65fa4d8573ce.png">
