### PR TITLE
Update cache flushing for other post types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.29.0
+VERSION := 3.29.1
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/CacheManager.php
+++ b/src/classes/CacheManager.php
@@ -229,6 +229,9 @@ namespace Niteo\WooCart\Defaults {
 				return false;
 			}
 
+			// Clear file status cache.
+			clearstatcache();
+
 			// Cache location.
 			$scan = new \RecursiveDirectoryIterator( $this->fcgi_path, \RecursiveDirectoryIterator::SKIP_DOTS );
 
@@ -270,7 +273,7 @@ namespace Niteo\WooCart\Defaults {
 				return;
 			}
 
-			if ( in_array( $post_type, array( 'post', 'page', 'product' ) ) ) {
+			if ( in_array( $post_type, array( 'post', 'page', 'product', 'product_variation', 'nav_menu_item' ) ) ) {
 				$this->flush_fcgi_cache();
 			}
 
@@ -280,11 +283,10 @@ namespace Niteo\WooCart\Defaults {
 		 * Flush FCGI cache for posts pages and orders.
 		 */
 		public function flush_fcgi_cache_selectively_on_delete( $post_id ) {
-
 			$post_type = get_post_type( $post_id );
 			// \WooCart\Log\Socket::log( ["kind"=>"flush_fcgi_cache_selectively_on_delete", "post"=>$post_type] );
 
-			if ( in_array( $post_type, array( 'post', 'page', 'product' ) ) ) {
+			if ( in_array( $post_type, array( 'post', 'page', 'product', 'product_variation', 'nav_menu_item' ) ) ) {
 				$this->flush_fcgi_cache();
 			}
 

--- a/src/classes/CacheManager.php
+++ b/src/classes/CacheManager.php
@@ -56,10 +56,13 @@ namespace Niteo\WooCart\Defaults {
 			// Runs after Customizer settings have been saved.
 			add_action( 'customize_save_after', array( &$this, 'flush_fcgi_cache' ) );
 
-			// Runs after post,page,product have benn updated
-			add_action( 'save_post_page', array( &$this, 'flush_fcgi_cache_selectively_on_save' ) );
-			add_action( 'save_post_post', array( &$this, 'flush_fcgi_cache_selectively_on_save' ) );
+			// save_post hooks runs for both post and page
+			add_action( 'save_post', array( &$this, 'flush_fcgi_cache_selectively_on_save' ) );
+
+			// Hooks for product, product_variation, and nav_menu_item
 			add_action( 'save_post_product', array( &$this, 'flush_fcgi_cache_selectively_on_save' ) );
+			add_action( 'save_post_product_variation', array( &$this, 'flush_fcgi_cache_selectively_on_save' ) );
+			add_action( 'save_post_nav_menu_item', array( &$this, 'flush_fcgi_cache_selectively_on_save' ) );
 
 			add_action( 'delete_post', array( &$this, 'flush_fcgi_cache_selectively_on_delete' ) );
 
@@ -291,6 +294,7 @@ namespace Niteo\WooCart\Defaults {
 			}
 
 		}
+
 		/**
 		 * Flush cache for Beaver builder.
 		 */

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -36,6 +36,11 @@ class CacheManagerTest extends TestCase {
 		\WP_Mock::expectActionAdded( 'upgrader_process_complete', array( $cache, 'flush_opcache' ) );
 		\WP_Mock::expectActionAdded( 'check_theme_switched', array( $cache, 'flush_opcache' ) );
 		\WP_Mock::expectActionAdded( 'customize_save_after', array( $cache, 'flush_fcgi_cache' ) );
+		\WP_Mock::expectActionAdded( 'save_post', array( $cache, 'flush_fcgi_cache_selectively_on_save' ) );
+		\WP_Mock::expectActionAdded( 'save_post_product', array( $cache, 'flush_fcgi_cache_selectively_on_save' ) );
+		\WP_Mock::expectActionAdded( 'save_post_product_variation', array( $cache, 'flush_fcgi_cache_selectively_on_save' ) );
+		\WP_Mock::expectActionAdded( 'save_post_nav_menu_item', array( $cache, 'flush_fcgi_cache_selectively_on_save' ) );
+		\WP_Mock::expectActionAdded( 'delete_post', array( $cache, 'flush_fcgi_cache_selectively_on_delete' ) );
 		\WP_Mock::expectActionAdded( 'woocommerce_reduce_order_stock', array( $cache, 'flush_fcgi_cache' ) );
 		\WP_Mock::expectActionAdded( 'elementor/editor/after_save', array( $cache, 'flush_fcgi_cache' ) );
 		\WP_Mock::expectActionAdded( 'fl_builder_after_save_layout', array( $cache, 'flush_fcgi_cache' ) );


### PR DESCRIPTION
This PR adds cache busting for `product_variation` and `nav_menu_item` post types.

I have not considered the following post types:

- custom_css
- customize_changeset
- revision
- shop_order

`custom_css` is part of the customizer process and the data is stored in the options table. We flush the cache when the options are updated.

`customize_changeset` is storing the customizer data so that the user does not lose it on switching the theme. Doesn't seem that important for cache-busting.

`revision` is when WP saves the post in the background and hence we should not be flushing cache for this.
