### PR TITLE
Clear fcgi ache after clean_term_cache has been called

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.29.1
+VERSION := 3.29.2
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/CacheManager.php
+++ b/src/classes/CacheManager.php
@@ -75,6 +75,9 @@ namespace Niteo\WooCart\Defaults {
 			// On Beaver Builder save flush caches
 			add_action( 'fl_builder_after_save_layout', array( &$this, 'flush_fcgi_cache' ) );
 
+			// After category,tag... update
+			add_action( 'clean_term_cache', array( &$this, 'flush_fcgi_cache' ) );
+
 			// Hook to the theme & plugin editor AJAX function.
 			// Priority set to -1 so that it runs before anything else.
 			add_action( 'wp_ajax_edit_theme_plugin_file', array( &$this, 'flush_cache' ), PHP_INT_MAX );

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -45,6 +45,7 @@ class CacheManagerTest extends TestCase {
 		\WP_Mock::expectActionAdded( 'elementor/editor/after_save', array( $cache, 'flush_fcgi_cache' ) );
 		\WP_Mock::expectActionAdded( 'fl_builder_after_save_layout', array( $cache, 'flush_fcgi_cache' ) );
 		\WP_Mock::expectActionAdded( 'wp_ajax_edit_theme_plugin_file', array( $cache, 'flush_cache' ), PHP_INT_MAX );
+		\WP_Mock::expectActionAdded( 'clean_term_cache', array( $cache, 'flush_fcgi_cache' ) );
 		\WP_Mock::expectActionAdded( 'init', array( $cache, 'nav_init' ) );
 
 		$cache->__construct();


### PR DESCRIPTION
When the user edits the category we also need to update the cache.