### PR TITLE
Update pagination restriction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.30.2
+VERSION := 3.30.3
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/CLICommand.php
+++ b/src/classes/CLICommand.php
@@ -525,5 +525,45 @@ namespace Niteo\WooCart\Defaults {
 				WP_CLI::error( $e->getMessage() );
 			}
 		}
+
+		/**
+		 * Toggle for the restrict pagination feature.
+		 *
+		 * ## OPTIONS
+		 *
+		 * <status>
+		 * : Pagination restriction status.
+		 * ---
+		 * options:
+		 *   - activate
+		 *   - deactivate
+		 *
+		 * ## EXAMPLES
+		 *
+		 *     wp wcd restrict_pagination activate
+		 *
+		 * @codeCoverageIgnore
+		 * @param $args array list of command line arguments.
+		 * @param $assoc_args array of named command line keys.
+		 * @throws WP_CLI\ExitException on wrong command.
+		 */
+		public function restrict_pagination( $args, $assoc_args ) {
+			try {
+				list($status) = $args;
+
+				if ( 'activate' === $status ) {
+					update_option( 'woocart_disable_restrict_pagination', false );
+				}
+
+				if ( 'deactivate' === $status ) {
+					update_option( 'woocart_disable_restrict_pagination', true );
+				}
+
+				WP_CLI::log( sprintf( 'Pagination restriction has been %sd.', $status ) );
+			} catch ( \Exception $e ) {
+				WP_CLI::log( 'There was an error processing your request.' );
+				WP_CLI::error( $e );
+			}
+		}
 	}
 }

--- a/src/classes/WordPress.php
+++ b/src/classes/WordPress.php
@@ -313,6 +313,11 @@ namespace Niteo\WooCart\Defaults {
 		public function restrict_pagination() {
 			global $pagenow;
 
+			// Check if this feature is not disabled.
+			if ( get_option( 'woocart_disable_restrict_pagination' ) ) {
+				return;
+			}
+
 			$user             = \wp_get_current_user();
 			$pagination_limit = 20;
 
@@ -333,6 +338,10 @@ namespace Niteo\WooCart\Defaults {
 					$option     = \sanitize_text_field( $_GET['post_type'] );
 					$pagination = \get_user_meta( $user->ID, "edit_{$option}_per_page", true );
 
+					if ( ! $pagination ) {
+						\update_user_meta( $user->ID, "edit_{$option}_per_page", $pagination_limit );
+					}
+
 					if ( $pagination_limit >= $pagination ) {
 						return;
 					}
@@ -340,6 +349,10 @@ namespace Niteo\WooCart\Defaults {
 					\update_user_meta( $user->ID, "edit_{$option}_per_page", $pagination_limit );
 				} else {
 					$pagination = \get_user_meta( $user->ID, 'edit_post_per_page', true );
+
+					if ( ! $pagination ) {
+						\update_user_meta( $user->ID, 'edit_post_per_page', $pagination_limit );
+					}
 
 					if ( $pagination_limit >= $pagination ) {
 						return;
@@ -352,6 +365,10 @@ namespace Niteo\WooCart\Defaults {
 			// Comments
 			if ( 'edit-comments.php' === $pagenow ) {
 				$pagination = \get_user_meta( $user->ID, 'edit_comments_per_page', true );
+
+				if ( ! $pagination ) {
+					\update_user_meta( $user->ID, 'edit_comments_per_page', $pagination_limit );
+				}
 
 				if ( $pagination_limit >= $pagination ) {
 					return;
@@ -370,6 +387,10 @@ namespace Niteo\WooCart\Defaults {
 				$option     = \sanitize_text_field( $_GET['taxonomy'] );
 				$pagination = \get_user_meta( $user->ID, "edit_{$option}_per_page", true );
 
+				if ( ! $pagination ) {
+					\update_user_meta( $user->ID, "edit_{$option}_per_page", $pagination_limit );
+				}
+
 				if ( $pagination_limit >= $pagination ) {
 					return;
 				}
@@ -381,6 +402,10 @@ namespace Niteo\WooCart\Defaults {
 			if ( 'plugins.php' === $pagenow ) {
 				$pagination = \get_user_meta( $user->ID, 'plugins_per_page', true );
 
+				if ( ! $pagination ) {
+					\update_user_meta( $user->ID, 'plugins_per_page', $pagination_limit );
+				}
+
 				if ( $pagination_limit >= $pagination ) {
 					return;
 				}
@@ -391,6 +416,10 @@ namespace Niteo\WooCart\Defaults {
 			// Users
 			if ( 'users.php' === $pagenow ) {
 				$pagination = \get_user_meta( $user->ID, 'users_per_page', true );
+
+				if ( ! $pagination ) {
+					\update_user_meta( $user->ID, 'users_per_page', $pagination_limit );
+				}
 
 				if ( $pagination_limit >= $pagination ) {
 					return;
@@ -406,6 +435,11 @@ namespace Niteo\WooCart\Defaults {
 		 * @return void
 		 */
 		public function restrict_pagination_ui() {
+			// Check if this feature is not disabled.
+			if ( get_option( 'woocart_disable_restrict_pagination' ) ) {
+				return;
+			}
+
 			$js = '(function($) {
 				$(document).ready(function() {
 					if ($(".screen-per-page").length) {

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -647,14 +647,89 @@ class WordPressTest extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::restrict_pagination
 	 */
+	public function testRestrictPaginationDisabled() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->restrict_pagination() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::restrict_pagination
+	 */
 	public function testRestrictPaginationNoUser() {
 		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
 
 		\WP_Mock::userFunction(
 			'wp_get_current_user',
 			array(
 				'times'  => 1,
 				'return' => false,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->restrict_pagination() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::restrict_pagination
+	 */
+	public function testRestrictPaginationPostsNoOption() {
+		global $pagenow;
+
+		$pagenow   = 'edit.php';
+		$wordpress = new WordPress();
+
+		$user_class = (object) array(
+			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_get_current_user',
+			array(
+				'times'  => 1,
+				'return' => $user_class,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_user_meta',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'update_user_meta',
+			array(
+				'times'  => 1,
+				'return' => true,
 			)
 		);
 
@@ -673,6 +748,14 @@ class WordPressTest extends TestCase {
 
 		$user_class = (object) array(
 			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
 		);
 
 		\WP_Mock::userFunction(
@@ -709,6 +792,14 @@ class WordPressTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
 			'wp_get_current_user',
 			array(
 				'times'  => 1,
@@ -739,6 +830,65 @@ class WordPressTest extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::restrict_pagination
 	 */
+	public function testRestrictPaginationShopOrderNoOption() {
+		global $pagenow;
+
+		$pagenow           = 'edit.php';
+		$_GET['post_type'] = 'shop_order';
+
+		$wordpress = new WordPress();
+
+		$user_class = (object) array(
+			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_get_current_user',
+			array(
+				'times'  => 1,
+				'return' => $user_class,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'times'  => 1,
+				'return' => 'shop_order',
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_user_meta',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'update_user_meta',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->restrict_pagination() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::restrict_pagination
+	 */
 	public function testRestrictPaginationShopOrderFalse() {
 		global $pagenow;
 
@@ -749,6 +899,14 @@ class WordPressTest extends TestCase {
 
 		$user_class = (object) array(
 			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
 		);
 
 		\WP_Mock::userFunction(
@@ -795,6 +953,14 @@ class WordPressTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
 			'wp_get_current_user',
 			array(
 				'times'  => 1,
@@ -833,6 +999,57 @@ class WordPressTest extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::restrict_pagination
 	 */
+	public function testRestrictPaginationCommentsNoOption() {
+		global $pagenow;
+
+		$pagenow           = 'edit-comments.php';
+		$_GET['post_type'] = 'comments';
+
+		$wordpress = new WordPress();
+
+		$user_class = (object) array(
+			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_get_current_user',
+			array(
+				'times'  => 1,
+				'return' => $user_class,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_user_meta',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'update_user_meta',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->restrict_pagination() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::restrict_pagination
+	 */
 	public function testRestrictPaginationCommentsFalse() {
 		global $pagenow;
 
@@ -843,6 +1060,14 @@ class WordPressTest extends TestCase {
 
 		$user_class = (object) array(
 			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
 		);
 
 		\WP_Mock::userFunction(
@@ -881,6 +1106,14 @@ class WordPressTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
 			'wp_get_current_user',
 			array(
 				'times'  => 1,
@@ -911,6 +1144,65 @@ class WordPressTest extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::restrict_pagination
 	 */
+	public function testRestrictPaginationCategoriesNoOption() {
+		global $pagenow;
+
+		$pagenow          = 'edit-tags.php';
+		$_GET['taxonomy'] = 'category';
+
+		$wordpress = new WordPress();
+
+		$user_class = (object) array(
+			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_get_current_user',
+			array(
+				'times'  => 1,
+				'return' => $user_class,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'times'  => 1,
+				'return' => 'category',
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_user_meta',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'update_user_meta',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->restrict_pagination() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::restrict_pagination
+	 */
 	public function testRestrictPaginationCategoriesFalse() {
 		global $pagenow;
 
@@ -921,6 +1213,14 @@ class WordPressTest extends TestCase {
 
 		$user_class = (object) array(
 			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
 		);
 
 		\WP_Mock::userFunction(
@@ -967,6 +1267,14 @@ class WordPressTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
 			'wp_get_current_user',
 			array(
 				'times'  => 1,
@@ -1005,6 +1313,57 @@ class WordPressTest extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::restrict_pagination
 	 */
+	public function testRestrictPaginationUsersNoOption() {
+		global $pagenow;
+
+		$pagenow           = 'users.php';
+		$_GET['post_type'] = 'users';
+
+		$wordpress = new WordPress();
+
+		$user_class = (object) array(
+			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_get_current_user',
+			array(
+				'times'  => 1,
+				'return' => $user_class,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_user_meta',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'update_user_meta',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->restrict_pagination() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::restrict_pagination
+	 */
 	public function testRestrictPaginationUsersFalse() {
 		global $pagenow;
 
@@ -1015,6 +1374,14 @@ class WordPressTest extends TestCase {
 
 		$user_class = (object) array(
 			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
 		);
 
 		\WP_Mock::userFunction(
@@ -1053,6 +1420,14 @@ class WordPressTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
 			'wp_get_current_user',
 			array(
 				'times'  => 1,
@@ -1083,6 +1458,55 @@ class WordPressTest extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::restrict_pagination
 	 */
+	public function testRestrictPaginationPluginsNoOption() {
+		global $pagenow;
+
+		$pagenow   = 'plugins.php';
+		$wordpress = new WordPress();
+
+		$user_class = (object) array(
+			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_get_current_user',
+			array(
+				'times'  => 1,
+				'return' => $user_class,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_user_meta',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'update_user_meta',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->restrict_pagination() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::restrict_pagination
+	 */
 	public function testRestrictPaginationPluginsFalse() {
 		global $pagenow;
 
@@ -1091,6 +1515,14 @@ class WordPressTest extends TestCase {
 
 		$user_class = (object) array(
 			'ID' => 1,
+		);
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
 		);
 
 		\WP_Mock::userFunction(
@@ -1127,6 +1559,14 @@ class WordPressTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		\WP_Mock::userFunction(
 			'wp_get_current_user',
 			array(
 				'times'  => 1,
@@ -1157,8 +1597,34 @@ class WordPressTest extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::restrict_pagination_ui
 	 */
+	public function testRestrictPaginationUiDisabled() {
+		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEmpty( $wordpress->restrict_pagination_ui() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::restrict_pagination_ui
+	 */
 	public function testRestrictPaginationUi() {
 		$wordpress = new WordPress();
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
 
 		\WP_Mock::userFunction(
 			'wp_add_inline_script',


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/2184

This PR adds the option to disable pagination restriction via WP-CLI.

Command:

```
wp wcd restrict_pagination <status>
```

`<status>` can be activate or deactivate.