### PR TITLE
Cache for WC reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.30.3
+VERSION := 3.31.0
 PLUGINSLUG := woocart-defaults
 SRCPATH := $(shell pwd)/src
 

--- a/src/classes/CacheManager.php
+++ b/src/classes/CacheManager.php
@@ -18,6 +18,7 @@ namespace Niteo\WooCart\Defaults {
 	class CacheManager {
 
 		use Extend\NavCache;
+		use Extend\APICache;
 
 		/**
 		 * FCGI Cache path.
@@ -98,6 +99,9 @@ namespace Niteo\WooCart\Defaults {
 
 			// Nav-menu cache
 			add_action( 'init', array( $this, 'nav_init' ) );
+
+			// API cache
+			add_action( 'rest_api_init', array( $this, 'api_init' ) );
 		}
 
 		/**

--- a/src/classes/Extend/APICache.php
+++ b/src/classes/Extend/APICache.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Cache WooCommerce API requests.
+ *
+ * @package Niteo\WooCart\Defaults
+ */
+
+namespace Niteo\WooCart\Defaults\Extend;
+
+trait APICache {
+
+	/**
+	 * Endpoint to cache.
+	 *
+	 * @var string
+	 */
+	private $endpoint_to_cache = 'wc/v3/reports';
+
+	/**
+	 * Unique identifier for the cache.
+	 *
+	 * @var string
+	 */
+	private $cache_key;
+
+	/**
+	 * Cache key prefix.
+	 *
+	 * @var string
+	 */
+	private $cache_key_prefix = 'wc_reports_';
+
+	/**
+	 * Initialize API cache.
+	 *
+	 * @return void
+	 */
+	public function api_init() : void {
+		// Build cache key using API url.
+		$this->create_cache_key();
+
+		// Check if cache needs to be skipped.
+		if ( ! $this->cache_key ) {
+			return;
+		}
+
+		add_filter( 'rest_pre_dispatch', array( $this, 'serve_cache' ), PHP_INT_MAX, 3 );
+		add_filter( 'rest_pre_echo_response', array( $this, 'set_cache' ), PHP_INT_MAX, 3 );
+	}
+
+	/**
+	 * Create cache key using the requested API url.
+	 *
+	 * @return void
+	 */
+	public function create_cache_key() : void {
+		// Requested API url which is used to create cache.
+		$request_url = sanitize_text_field( $_SERVER['REQUEST_URI'] );
+
+		if ( ! $request_url ) {
+			return;
+		}
+
+		// Parse URL to check for path and query args.
+		$parsed_url = wp_parse_url( $request_url );
+
+		if ( ! isset( $parsed_url['path'] ) || empty( $parsed_url['path'] ) ) {
+			return;
+		}
+
+		// Do nothing if not a cacheable endpoint.
+		if ( false === strpos( $parsed_url['path'], $this->endpoint_to_cache ) ) {
+			return;
+		}
+
+		// Check for query args.
+		$params = array();
+
+		if ( isset( $parsed_url['query'] ) && ! empty( $parsed_url['query'] ) ) {
+			$params = wp_parse_args( $parsed_url['query'] );
+		}
+
+		// Set cache key.
+		$this->cache_key = $this->cache_key_prefix . md5( $parsed_url['path'] . wp_json_encode( $params ) );
+	}
+
+	/**
+	 * Serve data from cache if key exists.
+	 *
+	 * @param null             $result  Response data to send to the client.
+	 * @param \WP_REST_Server  $server  Server instance.
+	 * @param \WP_REST_Request $request Request used to generate the response.
+	 *
+	 * @return null|array
+	 */
+	public function serve_cache( $result, \WP_REST_Server $server, \WP_REST_Request $request ) {
+		// Check if cache exists.
+		$output = \get_transient( $this->cache_key );
+
+		if ( $output ) {
+			// Set content type to JSON and output response.
+			$this->set_header( 'Content-Type: application/json' );
+			echo wp_json_encode( $output );
+
+			// Terminate as the request is complete.
+			$this->exit();
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Set cache based on the endpoint and request type.
+	 *
+	 * @param array            $result  Response data to send to the client.
+	 * @param \WP_REST_Server  $server  Server instance.
+	 * @param \WP_REST_Request $request Request used to generate the response.
+	 *
+	 * @return array
+	 */
+	public function set_cache( $result, \WP_REST_Server $server, \WP_REST_Request $request ) : array {
+		// Ensure result is not empty.
+		if ( empty( $result ) ) {
+			return $result;
+		}
+
+		// Ignore any response other than 200.
+		if ( is_array( $result )
+		&& isset( $result['data']['status'] )
+		&& 200 !== (int) $result['data']['status']
+		) {
+			return $result;
+		}
+
+		// Set transient.
+		\set_transient( $this->cache_key, $result, HOUR_IN_SECONDS );
+
+		return $result;
+	}
+
+	/**
+	 * Wrapper for the header function.
+	 *
+	 * @param  string $header Header value to be set.
+	 * @return void
+	 * @codeCoverageIgnore
+	 */
+	protected function set_header( $header ) : void {
+		header( $header );
+	}
+
+	/**
+	 * Wrapper for the exit function.
+	 *
+	 * @return void
+	 * @codeCoverageIgnore
+	 */
+	protected function exit() : void {
+		exit;
+	}
+
+}

--- a/tests/ApiCacheTest.php
+++ b/tests/ApiCacheTest.php
@@ -1,0 +1,293 @@
+<?php
+
+use Niteo\WooCart\Defaults\CacheManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Niteo\WooCart\Defaults\CacheManager
+ */
+class ApiCacheTest extends TestCase {
+
+	public function setUp() : void {
+		\WP_Mock::setUp();
+	}
+
+	public function tearDown() : void {
+		$this->addToAssertionCount(
+			\Mockery::getContainer()->mockery_getExpectationCount()
+		);
+		\WP_Mock::tearDown();
+		\Mockery::close();
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::api_init
+	 */
+	public function testApiInitNoCacheKey() {
+		$cache = \Mockery::mock( CacheManager::class )->makePartial();
+		$cache->shouldReceive( 'create_cache_key' )->andReturn( false );
+
+		$this->assertEmpty( $cache->api_init() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::api_init
+	 * @covers ::create_cache_key
+	 */
+	public function testApiInitWithCacheKey() {
+		$cache                  = new CacheManager();
+		$_SERVER['REQUEST_URI'] = 'https://api.test/wp-json/wc/v3/reports?period=week';
+
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'times'  => 1,
+				'return' => 'https://api.test/wp-json/wc/v3/reports?period=week',
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_parse_url',
+			array(
+				'times'  => 1,
+				'return' => array(
+					'path'  => 'https://api.test/wp-json/wc/v3/reports',
+					'query' => 'period=week',
+				),
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_parse_args',
+			array(
+				'times'  => 1,
+				'return' => array(
+					'period' => 'week',
+				),
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_json_encode',
+			array(
+				'times'  => 1,
+				'return' => 'JSON_ENCODED_STRING',
+			)
+		);
+
+		\WP_Mock::expectFilterAdded( 'rest_pre_dispatch', array( $cache, 'serve_cache' ), PHP_INT_MAX, 3 );
+		\WP_Mock::expectFilterAdded( 'rest_pre_echo_response', array( $cache, 'set_cache' ), PHP_INT_MAX, 3 );
+
+		$cache->api_init();
+		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::create_cache_key
+	 */
+	public function testCreateCacheKeyNoUrl() {
+		$cache                  = new CacheManager();
+		$_SERVER['REQUEST_URI'] = '';
+
+		$this->assertEmpty( $cache->create_cache_key() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::create_cache_key
+	 */
+	public function testCreateCacheKeyNoPathSet() {
+		$cache                  = new CacheManager();
+		$_SERVER['REQUEST_URI'] = 'https://api.test/wp-json/wc/v3/orders';
+
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'times'  => 1,
+				'return' => 'https://api.test/wp-json/wc/v3/orders',
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_parse_url',
+			array(
+				'times'  => 1,
+				'return' => array(),
+			)
+		);
+
+		$this->assertEmpty( $cache->create_cache_key() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::create_cache_key
+	 */
+	public function testCreateCacheKeyDiffUrl() {
+		$cache                  = new CacheManager();
+		$_SERVER['REQUEST_URI'] = 'https://api.test/wp-json/wc/v3/orders';
+
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'times'  => 1,
+				'return' => 'https://api.test/wp-json/wc/v3/orders',
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_parse_url',
+			array(
+				'times'  => 1,
+				'return' => array(
+					'path' => 'https://api.test/wp-json/wc/v3/orders',
+				),
+			)
+		);
+
+		$this->assertEmpty( $cache->create_cache_key() );
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::serve_cache
+	 */
+	public function testServeCacheNoTransient() {
+		$cache = new CacheManager();
+
+		\WP_Mock::userFunction(
+			'get_transient',
+			array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		$this->assertEquals(
+			array( 'NOT_CACHED_RESULT' ),
+			$cache->serve_cache(
+				array( 'NOT_CACHED_RESULT' ),
+				\Mockery::mock( \WP_REST_Server::class ),
+				\Mockery::mock( \WP_REST_Request::class )
+			)
+		);
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::serve_cache
+	 */
+	public function testServeCacheWithTransient() {
+		$cache = \Mockery::mock( CacheManager::class )->makePartial()->shouldAllowMockingProtectedMethods();
+		$cache->shouldReceive( 'set_header' )->andReturn( true );
+		$cache->shouldReceive( 'exit' )->andReturn( true );
+
+		\WP_Mock::userFunction(
+			'get_transient',
+			array(
+				'times'  => 1,
+				'return' => array(
+					'content' => 'FROM CACHE',
+				),
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_json_encode',
+			array(
+				'times'  => 1,
+				'return' => '{"content":"FROM CACHE"}',
+			)
+		);
+
+		$this->expectOutputString( '{"content":"FROM CACHE"}' );
+		$cache->serve_cache(
+			array( 'NOT_CACHED_RESULT' ),
+			\Mockery::mock( \WP_REST_Server::class ),
+			\Mockery::mock( \WP_REST_Request::class )
+		);
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::set_cache
+	 */
+	public function testSetCacheEmptyResult() {
+		$cache = new CacheManager();
+
+		$this->assertEquals(
+			array(),
+			$cache->set_cache(
+				array(),
+				\Mockery::mock( \WP_REST_Server::class ),
+				\Mockery::mock( \WP_REST_Request::class )
+			)
+		);
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::set_cache
+	 */
+	public function testSetCacheDiffResponse() {
+		$cache = new CacheManager();
+
+		$this->assertEquals(
+			array(
+				'data' => array(
+					'status' => 400,
+				),
+			),
+			$cache->set_cache(
+				array(
+					'data' => array(
+						'status' => 400,
+					),
+				),
+				\Mockery::mock( \WP_REST_Server::class ),
+				\Mockery::mock( \WP_REST_Request::class )
+			)
+		);
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::set_cache
+	 */
+	public function testSetCacheTrue() {
+		$cache = new CacheManager();
+
+		define( 'HOUR_IN_SECONDS', 3600 );
+
+		\WP_Mock::userFunction(
+			'set_transient',
+			array(
+				'times'  => 1,
+				'return' => true,
+			)
+		);
+
+		$this->assertEquals(
+			array(
+				'data' => array(
+					'status'   => 200,
+					'response' => 'API RESPONSE TO CACHE',
+				),
+			),
+			$cache->set_cache(
+				array(
+					'data' => array(
+						'status'   => 200,
+						'response' => 'API RESPONSE TO CACHE',
+					),
+				),
+				\Mockery::mock( \WP_REST_Server::class ),
+				\Mockery::mock( \WP_REST_Request::class )
+			)
+		);
+	}
+
+}

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -47,6 +47,7 @@ class CacheManagerTest extends TestCase {
 		\WP_Mock::expectActionAdded( 'wp_ajax_edit_theme_plugin_file', array( $cache, 'flush_cache' ), PHP_INT_MAX );
 		\WP_Mock::expectActionAdded( 'clean_term_cache', array( $cache, 'flush_fcgi_cache' ) );
 		\WP_Mock::expectActionAdded( 'init', array( $cache, 'nav_init' ) );
+		\WP_Mock::expectActionAdded( 'rest_api_init', array( $cache, 'api_init' ) );
 
 		$cache->__construct();
 		\WP_Mock::assertHooksAdded();


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/2030

This PR adds `APICache` trait which is used in the `CacheManager` class for adding caching for the WC reports endpoints.

To-do:

- [x] Fix cache logic
- [x] Tests